### PR TITLE
CORCI-504 Add checkoutScm step.

### DIFF
--- a/src/com/intel/checkoutScmInternal.groovy
+++ b/src/com/intel/checkoutScmInternal.groovy
@@ -33,15 +33,16 @@ def checkoutScmInternal(Map config = [:]) {
   }
   branches = scm.branches
   if (config['url']) {
-    userRemoteConfigs = [[url: config['url']]]
+    userRemoteConfig = [url: config['url']]
     if (config['branch']) {
       branches = [[name: config['branch']]]
     } else {
       branches = [[name: '*/master']]
     }
     if (config['credentialsId']) {
-      userRemoteConfigs.add([credentialsId: config['credentialsId']])
+      userRemoteConfig.add([credentialsId: config['credentialsId']])
     }
+    UserRemoteConfigs = [userRemoteConfig]
   } else {
     userRemoteConfigs = scm.userRemoteConfigs
   }

--- a/src/com/intel/checkoutScmInternal.groovy
+++ b/src/com/intel/checkoutScmInternal.groovy
@@ -42,7 +42,7 @@ def checkoutScmInternal(Map config = [:]) {
     if (config['credentialsId']) {
       userRemoteConfig.add([credentialsId: config['credentialsId']])
     }
-    UserRemoteConfigs = [userRemoteConfig]
+    userRemoteConfigs = [userRemoteConfig]
   } else {
     userRemoteConfigs = scm.userRemoteConfigs
   }

--- a/src/com/intel/checkoutScmInternal.groovy
+++ b/src/com/intel/checkoutScmInternal.groovy
@@ -40,7 +40,7 @@ def checkoutScmInternal(Map config = [:]) {
       branches = [[name: '*/master']]
     }
     if (config['credentialsId']) {
-      userRemoteConfig.add([credentialsId: config['credentialsId']])
+      userRemoteConfig.put([credentialsId: config['credentialsId']])
     }
     userRemoteConfigs = [userRemoteConfig]
   } else {

--- a/src/com/intel/checkoutScmInternal.groovy
+++ b/src/com/intel/checkoutScmInternal.groovy
@@ -1,0 +1,74 @@
+// src/com/intel/checkoutScmInternal.groovy
+
+package com.intel
+
+/**
+ * checkoutScmInternal.groovy
+ *
+ * Simplified Scm checkout routine.
+ */
+
+
+def checkoutScmInternal(Map config = [:]) {
+  /**
+   * Simplified SCM checkout method.
+   *
+   * @param config Map of parameters passed
+   * @return Map of any variables the SCM plugin would set in a
+   * Freestyle job.
+   *
+   * config['scm'] SCM name, defaults to 'GitSCM'.
+   * config['url'] Url for SCM repository.  If not specified,
+   *  defaults will be used from the scm global variable.
+   * config['cleanAfterCheckout'] True for clean after checkout.
+   * config['checkoutDir'] Optional directory to checkout into.
+   * config['branch'] Optional branch to checkout, defaults to master.
+   * config['withSubmodules'] Optional checkout submodules if true.
+   * config['credentialsId'] Optional credentials ID.
+   */
+
+  scm_name = 'GitSCM'
+  if (config['scm']) {
+    scm_name = config['scm']
+  }
+  branches = scm.branches
+  if (config['url']) {
+    userRemoteConfigs = [[url: config['url']]]
+    if (config['branch']) {
+      branches = [[name: config['branch']]]
+    } else {
+      branches = [[name: '*/master']]
+    }
+    if (config['credentialId']) {
+      userRemoteConfigs.add([credentialsId: config['credentialsId']])
+    }
+  } else {
+    userRemoteConfigs = scm.userRemoteConfigs
+  }
+  params = [$class: scm_name,
+            branches: branches,
+            extensions: [],
+            submoduleCfg: [],
+            userRemoteConfigs: userRemoteConfigs]
+  if (config['CleanAfterCheckout']) {
+    params['extensions'].add([$class: 'CleanCheckout'])
+  }
+
+  if (config['checkoutDir']) {
+    params['extensions'].add(
+      [$class: 'RelativeTargetDirectory',
+       relativeTargetDir: config['checkoutDir']])
+  }
+
+  if (config['withSubmodules']) {
+    params['extensions'].add(
+      [$class: 'SubmoduleOption',
+       disableSubmodules: false,
+       parentCredentials: true,
+       recursiveSubmodules: true,
+       reference: '',
+       trackingSubmodules: false])
+  }
+
+  return checkout(params)
+}

--- a/src/com/intel/checkoutScmInternal.groovy
+++ b/src/com/intel/checkoutScmInternal.groovy
@@ -40,7 +40,7 @@ def checkoutScmInternal(Map config = [:]) {
       branches = [[name: '*/master']]
     }
     if (config['credentialsId']) {
-      userRemoteConfig.put([credentialsId: config['credentialsId']])
+      userRemoteConfig << [credentialsId: config['credentialsId']]
     }
     userRemoteConfigs = [userRemoteConfig]
   } else {

--- a/src/com/intel/checkoutScmInternal.groovy
+++ b/src/com/intel/checkoutScmInternal.groovy
@@ -39,7 +39,7 @@ def checkoutScmInternal(Map config = [:]) {
     } else {
       branches = [[name: '*/master']]
     }
-    if (config['credentialId']) {
+    if (config['credentialsId']) {
       userRemoteConfigs.add([credentialsId: config['credentialsId']])
     }
   } else {

--- a/vars/checkPatch.groovy
+++ b/vars/checkPatch.groovy
@@ -28,7 +28,7 @@ def call(Map config = [:]) {
       return
     }
 
-    checkoutSCM withSubmodules: true
+    checkoutScm withSubmodules: true
     if (config['jenkins_review']) {
         rev_num = config['jenkins_review']
         branch = 'FETCH_HEAD'
@@ -44,7 +44,7 @@ def call(Map config = [:]) {
     }
 
     // Need the jenkins module to do linting
-    checkoutSCM url: 'ssh://review.hpdd.intel.com:29418/exascale/jenkins',
+    checkoutScm url: 'ssh://review.hpdd.intel.com:29418/exascale/jenkins',
                 checkoutDir: 'jenkins',
                 credentialsId: 'bf21c68b-9107-4a38-8077-e929e644996a'
 

--- a/vars/checkoutScm.groovy
+++ b/vars/checkoutScm.groovy
@@ -1,0 +1,32 @@
+// vars/checkoutScm.groovy
+
+import com.intel.checkoutScmInternal
+
+/**
+ * checkoutGit.groovy
+ *
+ * checkoutGit pipeline step
+ *
+ */
+
+
+def call(Map config = [:]) {
+  /**
+   * Simplified SCM checkout method.
+   *
+   * @param config Map of parameters passed
+   * @return Map of any variables the SCM plugin would set in a
+   * Freestyle job.
+   *
+   * config['scm'] SCM name, defaults to 'GitSCM'.
+   * config['url'] Url for Git repository.  If not specified,
+   *  defaults will be used from the scm global variable.
+   * config['cleanAfterCheckout'] True for clean after checkout.
+   * config['checkoutDir'] Optional directory to checkout into.
+   * config['branch'] Optional branch to checkout, defaults to master.
+   * config['withSubmodules'] Optional checkout submodules if true.
+   * config['credentialsId'] Optional credentials ID.
+   */
+  def c = new com.intel.checkoutScmInternal()
+  return c.checkoutScmInternal(config)
+}

--- a/vars/checkoutScm.groovy
+++ b/vars/checkoutScm.groovy
@@ -3,9 +3,9 @@
 import com.intel.checkoutScmInternal
 
 /**
- * checkoutGit.groovy
+ * checkoutSCM.groovy
  *
- * checkoutGit pipeline step
+ * checkoutSCM pipeline step
  *
  */
 

--- a/vars/checkoutScm.groovy
+++ b/vars/checkoutScm.groovy
@@ -3,9 +3,9 @@
 import com.intel.checkoutScmInternal
 
 /**
- * checkoutSCM.groovy
+ * checkoutScm.groovy
  *
- * checkoutSCM pipeline step
+ * checkoutScm pipeline step
  *
  */
 

--- a/vars/sconsBuild.groovy
+++ b/vars/sconsBuild.groovy
@@ -1,8 +1,11 @@
 // vars/sconsBuild.groovy
 
+import com.intel.checkoutScm
+
 def call(Map config) {
 
-    checkoutSCM withSubmodules: true
+    def c = new com.intel.checkoutScm()
+    c.checkoutScmWithSubmodules()
 
     githubNotify credentialsId: 'daos-jenkins-commit-status',
                  description: env.STAGE_NAME,
@@ -14,7 +17,7 @@ def call(Map config) {
                 fi
                 scons -c
                 # scons -c is not perfect so get out the big hammer
-                rm -rf _build.external* install build
+                rm -rf _build.external install build
                 SCONS_ARGS="--update-prereq=all --build-deps=yes USE_INSTALLED=all install"
                 # the config cache is unreliable so always force a reconfig
                 # with "--config=force"

--- a/vars/sconsBuild.groovy
+++ b/vars/sconsBuild.groovy
@@ -1,11 +1,8 @@
 // vars/sconsBuild.groovy
 
-import com.intel.checkoutScm
-
 def call(Map config) {
 
-    def c = new com.intel.checkoutScm()
-    c.checkoutScmWithSubmodules()
+    checkoutSCM withSubmodules: true
 
     githubNotify credentialsId: 'daos-jenkins-commit-status',
                  description: env.STAGE_NAME,
@@ -17,7 +14,7 @@ def call(Map config) {
                 fi
                 scons -c
                 # scons -c is not perfect so get out the big hammer
-                rm -rf _build.external install build
+                rm -rf _build.external* install build
                 SCONS_ARGS="--update-prereq=all --build-deps=yes USE_INSTALLED=all install"
                 # the config cache is unreliable so always force a reconfig
                 # with "--config=force"


### PR DESCRIPTION
Add simplified scm step that allows optional parameters of:

   * scm: SCM name, defaults to 'GitSCM'.
   * url: Url for Git repository.  If not specified,
   *  defaults will be used from the scm global variable.
   * cleanAfterCheckout: True for clean after checkout.
   * checkoutDir: Optional directory to checkout into.
   * branch: Optional branch to checkout, defaults to master.
   * withSubmodules: Optional checkout submodules if true.
   * credentialsId: Optional credentials ID.

Signed-off-by: John.E.Malmberg <john.e.malmberg@intel.com>