### PR TITLE
Don't overwrite the test's UNSTABLE/FAILED result

### DIFF
--- a/vars/runTest.groovy
+++ b/vars/runTest.groovy
@@ -45,8 +45,4 @@ def call(Map config) {
         }
     }
     stepResult name: env.STAGE_NAME, context: "test", result: status
-
-    if (status != "SUCCESS") {
-        error "Failure in runTest"
-    }
 }


### PR DESCRIPTION
By calling error() when the result != SUCCESS.