### PR TITLE
CORCI-522 Add a link to the log pointing at an artifact

### DIFF
--- a/vars/runTest.groovy
+++ b/vars/runTest.groovy
@@ -1,6 +1,24 @@
 // vars/runTest.groovy
 
+/**
+ * runTest.groovy
+ *
+ * runTest pipeline step
+ *
+ */
+
 def call(Map config) {
+  /**
+   * runTest step method
+   *
+   * @param config Map of parameters passed
+   * @return None
+   *
+   * config['junit_files'] Junit files to look for errors in
+   * config['script'] The test code to run
+   * config['stashes'] Stashes from the build to unstash
+   * config['failure_artifacts'] Artifacts to link to when test fails, if any
+   */
 
     dir('install') {
         deleteDir()
@@ -17,6 +35,11 @@ def call(Map config) {
     def script = '''if git show -s --format=%B | grep "^Skip-test: true"; then
                         exit 0
                     fi\n''' + config['script']
+    if (config['failure_artifacts']) {
+        script += '''\nset +x\necho -n "Test artifacts can be found at: "
+                     echo "${JOB_URL%/job/*}/view/change-requests/job/$BRANCH_NAME/$BUILD_ID/artifact/''' +
+                          config['failure_artifacts'] + '"'
+    }
 
     int rc = 0
     rc = sh(script: script, label: env.STAGE_NAME, returnStatus: true)

--- a/vars/sconsBuild.groovy
+++ b/vars/sconsBuild.groovy
@@ -45,6 +45,7 @@ def call(Map config = [:]) {
    * config['update_prereq'] Setting for --update-prereq.  Default 'all'.
    * config['USE_INSTALLED'] setting for USE_INSTALLED.  Default 'yes'.
    *  If false, a failure of the scons commands will cause this step to fail.
+   * config['failure_artifacts'] Artifacts to link to when scons fails
    */
 
     /* If we have to tamper with the checkout, we also need to remove
@@ -176,7 +177,10 @@ def call(Map config = [:]) {
                  if ! scons --config=force $SCONS_ARGS; then
                      rc=\${PIPESTATUS[0]}
                      echo "scons failed: \$rc."
-                     echo "Look in the artifacts for the config.log."
+                     set +x
+                     echo -n "If the error is not in the output above, it might be in the config.log: "
+                     echo "${JOB_URL%/job/*}/view/change-requests/job/$BRANCH_NAME/$BUILD_ID/artifact/''' +
+                          config['failure_artifacts'] + '"' + '''
                      exit \$rc
                  fi'''
     def full_script = "#!/bin/bash\nset -e\n" +


### PR DESCRIPTION
When a build or test job fails.

Requires the build/test job to inform of the artifact to add the link to.