### PR TITLE
DCO-8578 Remove installing of libipmctl

### DIFF
--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -113,19 +113,14 @@ def call(Map config = [:]) {
                               chmod 600 /localhome/jenkins/.ssh/{authorized_keys,id_rsa*}
                               chown -R jenkins.jenkins /localhome/jenkins/.ssh
                               echo \\"jenkins ALL=(ALL) NOPASSWD: ALL\\" > /etc/sudoers.d/jenkins
-                              yum copr -y enable jhli/ipmctl
-                              yum copr -y enable jhli/safeclib
                               yum install -y epel-release
                               yum install -y openmpi CUnit fuse python34-PyYAML python34-nose    \
                                              python34-pip valgrind python34-paramiko             \
                                              python2-avocado python2-avocado-plugins-output-html \
                                              python2-avocado-plugins-varianter-yaml-to-mux       \
                                              python-debuginfo python2-aexpect libcmocka          \
-                                             yum-plugin-copr python-pathlib python2-numpy git    \
-                                             golang-bin
-                              yum copr -y enable jhli/ipmctl
-                              yum copr -y enable jhli/safeclib
-                              yum install -y libipmctl'''
+                                             python-pathlib python2-numpy git                    \
+                                             golang-bin'''
     sh script: 'set -x; rm -f ci_key*; ssh-keygen -N "" -f ci_key;' +
                ' pdcp -R ssh -l root -w ' + nodeString +
                ' ci_key* /tmp/;' +


### PR DESCRIPTION
libipmctl is being installed on the provisioned test nodes by
chef, so we don't need to install it in provisionNodes also.