### PR TITLE
CORCI-640 Create python3 symlink

### DIFF
--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -120,7 +120,11 @@ def call(Map config = [:]) {
                                              python2-avocado-plugins-varianter-yaml-to-mux       \
                                              python-debuginfo python2-aexpect libcmocka          \
                                              python-pathlib python2-numpy git                    \
-                                             golang-bin'''
+                                             golang-bin
+                              if [ ! -e /usr/bin/python3 ] &&
+                                 [ -e /usr/bin/python3.4 ]; then
+                                  ln -s python3.4 /usr/bin/python3
+                              fi'''
     def rc = 0
     rc = sh(script: 'set -x; rm -f ci_key*; ssh-keygen -N "" -f ci_key;' +
                     ' pdcp -R ssh -l root -w ' + nodeString +


### PR DESCRIPTION
python34-3.4.9-3.el7.x86_64 seems to have removed the
python3 -> python3.4 symlink that existed previous to it.  This is
breaking our usages of python3.

Create the symlink if it doesn't exist.