### PR TITLE
CORCI-640 Create pip3 symlink (#37)

### DIFF
--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -121,6 +121,10 @@ def call(Map config = [:]) {
                                              python-debuginfo python2-aexpect libcmocka          \
                                              python-pathlib python2-numpy git                    \
                                              golang-bin
+                              if [ ! -e /usr/bin/pip3 ] &&
+                                 [ -e /usr/bin/pip3.4 ]; then
+                                  ln -s pip3.4 /usr/bin/pip3
+                              fi
                               if [ ! -e /usr/bin/python3 ] &&
                                  [ -e /usr/bin/python3.4 ]; then
                                   ln -s python3.4 /usr/bin/python3


### PR DESCRIPTION
python34-pip-8.1.2-8.el7.noarch.rpm seems to have removed the
pip3 -> pip3.4 symlink that existed previous to it.  This is
breaking our usages of pip3.

Create the symlink if it doesn't exist.