### PR TITLE
CORCI-644 GitHub status for junit tests should point to the result

### DIFF
--- a/vars/runTest.groovy
+++ b/vars/runTest.groovy
@@ -89,5 +89,6 @@ def call(Map config = [:]) {
             status = "SUCCESS"
         }
     }
-    stepResult name: env.STAGE_NAME, context: "test", result: status
+    stepResult name: env.STAGE_NAME, context: "test", result: status,
+               junit_files: config['junit_files']
 }

--- a/vars/stepResult.groovy
+++ b/vars/stepResult.groovy
@@ -20,6 +20,7 @@ def call(Map config= [:]) {
    * config['ignore_failure'] Whether a FAILURE result should post a failed step.
    * config['name'] The description to post in the GitHub commit status.
    * config['context'] The context to post in the GitHub commit status.
+   * config['junit_files'] The names of any available junit files.
    */
 
     node {
@@ -30,50 +31,56 @@ def call(Map config= [:]) {
           return
         }
 
-        def jsonSlurperClassic = new JsonSlurperClassic()
-
-        def h = new com.intel.doGetHttpRequest()
-        resp = h.doGetHttpRequest(env.JOB_URL - ~/job\/[^\/]*\/$/ +
-            "/view/change-requests/job/${env.BRANCH_NAME}/" +
-            "${env.BUILD_ID}/wfapi/describe");
-
-        def job = jsonSlurperClassic.parseText(resp)
-        assert job instanceof Map
-
-        def stage
-        for (s in job['stages']) {
-            if (s['name'] == env.STAGE_NAME) {
-                stage = s
-                break
-            }
-        }
-
-        resp = h.doGetHttpRequest("${env.JENKINS_URL}" + stage['_links']['self']['href'])
-
-        stage = jsonSlurperClassic.parseText(resp)
-        assert stage instanceof Map
-
-        def stageFlowNode = null
-
-        for (s in stage['stageFlowNodes']) {
-            if (s['name'] == env.STAGE_NAME) {
-                stageFlowNode = s
-                break
-            }
-        }
-        if (!stageFlowNode) {
-            echo("No step named \"" + env.STAGE_NAME + "\" could be found for this stage.")
-            config['result'] = "FAILURE"
-            config['ignore_failure'] = false
+        if (config['junit_files'] && config['result] !="FAILURE") {
+            log_url = env.JOB_URL - ~/job\/[^\/]*\/$/ +
+                      "/view/change-requests/job/${env.BRANCH_NAME}/" +
+                      "${env.BUILD_ID}/testReport/")
         } else {
-            resp = h.doGetHttpRequest("${env.JENKINS_URL}" + stageFlowNode['_links']['log']['href'])
+            def jsonSlurperClassic = new JsonSlurperClassic()
 
-            log = jsonSlurperClassic.parseText(resp)
-            assert log instanceof Map
+            def h = new com.intel.doGetHttpRequest()
+            resp = h.doGetHttpRequest(env.JOB_URL - ~/job\/[^\/]*\/$/ +
+                "/view/change-requests/job/${env.BRANCH_NAME}/" +
+                "${env.BUILD_ID}/wfapi/describe");
 
-            log_url = "${env.JENKINS_URL}${log.consoleUrl}"
+            def job = jsonSlurperClassic.parseText(resp)
+            assert job instanceof Map
+
+            def stage
+            for (s in job['stages']) {
+                if (s['name'] == env.STAGE_NAME) {
+                    stage = s
+                    break
+                }
+            }
+
+            resp = h.doGetHttpRequest("${env.JENKINS_URL}" + stage['_links']['self']['href'])
+
+            stage = jsonSlurperClassic.parseText(resp)
+            assert stage instanceof Map
+
+            def stageFlowNode = null
+
+            for (s in stage['stageFlowNodes']) {
+                if (s['name'] == env.STAGE_NAME) {
+                    stageFlowNode = s
+                    break
+                }
+            }
+            if (!stageFlowNode) {
+                echo("No step named \"" + env.STAGE_NAME + "\" could be found for this stage.")
+                config['result'] = "FAILURE"
+                config['ignore_failure'] = false
+            } else {
+                resp = h.doGetHttpRequest("${env.JENKINS_URL}" + stageFlowNode['_links']['log']['href'])
+
+                log = jsonSlurperClassic.parseText(resp)
+                assert log instanceof Map
+
+                log_url = "${env.JENKINS_URL}${log.consoleUrl}"
+            }
+            jsonSlurperClassic = null
         }
-        jsonSlurperClassic = null
 
         if (!config['ignore_failure']) {
             currentBuild.result = config.get('result')

--- a/vars/stepResult.groovy
+++ b/vars/stepResult.groovy
@@ -31,10 +31,10 @@ def call(Map config= [:]) {
           return
         }
 
-        if (config['junit_files'] && config['result] !="FAILURE") {
+        if (config['junit_files'] && config['result'] != 'FAILURE') {
             log_url = env.JOB_URL - ~/job\/[^\/]*\/$/ +
                       "/view/change-requests/job/${env.BRANCH_NAME}/" +
-                      "${env.BUILD_ID}/testReport/")
+                      "${env.BUILD_ID}/testReport/"
         } else {
             def jsonSlurperClassic = new JsonSlurperClassic()
 

--- a/vars/stepResult.groovy
+++ b/vars/stepResult.groovy
@@ -34,7 +34,7 @@ def call(Map config= [:]) {
         if (config['junit_files'] && config['result'] != 'FAILURE') {
             log_url = env.JOB_URL - ~/job\/[^\/]*\/$/ +
                       "/view/change-requests/job/${env.BRANCH_NAME}/" +
-                      "${env.BUILD_ID}/testReport/"
+                      "${env.BUILD_ID}/testReport/(root)/"
         } else {
             def jsonSlurperClassic = new JsonSlurperClassic()
 


### PR DESCRIPTION
For GitHub test stages that produce junit output, if the result is not a
failure (i.e. the tests even failed to run) the Detail link should point
to the Jenkins job's test result.