### PR TITLE
Post an error to the job if runTest stage fails

### DIFF
--- a/vars/runTest.groovy
+++ b/vars/runTest.groovy
@@ -89,5 +89,11 @@ def call(Map config = [:]) {
             status = "SUCCESS"
         }
     }
+
     stepResult name: env.STAGE_NAME, context: "test", result: status
+
+    if (status == 'FAILURE') {
+        error(env.STAGE_NAME + " failed: " + rc)
+    }
+
 }


### PR DESCRIPTION
This is what signals the pipeline to not continue beyond the run_test.sh
state if it fails for example.