### PR TITLE
Revert "CORCI-660 Only do a checkoutScm() if an scm parameter was defined (#43)"

### DIFF
--- a/vars/sconsBuild.groovy
+++ b/vars/sconsBuild.groovy
@@ -67,8 +67,8 @@ def call(Map config = [:]) {
         if (config['target'] && !scm_config['checkoutDir']) {
             scm_config['checkoutDir'] = config['target']
         }
-        checkoutScm(scm_config)
     }
+    checkoutScm(scm_config)
     if (env.DAOS_JENKINS_NOTIFY_STATUS != null) {
         githubNotify credentialsId: 'daos-jenkins-commit-status',
                      description: env.STAGE_NAME,


### PR DESCRIPTION
This reverts commit a1e110a5afdb97efda2a4c490a69d9863b3921ca.

The checkoutScm() is always needed to get the submodules.

Will need to achieve CORCI-660's goal without removing the checkout.