### PR TITLE
CORCI-663 build: use cat instead of true

### DIFF
--- a/vars/sconsBuild.groovy
+++ b/vars/sconsBuild.groovy
@@ -49,7 +49,7 @@ def call(Map config = [:]) {
    * config['log_to_file'] Copy build output to a file
    */
 
-    def tee_file = '| true'
+    def tee_file = '| cat'
     if (config['log_to_file']) {
         tee_file = "| tee ${WORKSPACE}/" + config['log_to_file']
     }


### PR DESCRIPTION
As true seems to cause it's stdin producer to have issues as well as it
consumes it's stdin which wee don't really want to do.