### PR TITLE
CORCI-675 Remove python2-aexpect from post provision install

### DIFF
--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -121,7 +121,7 @@ def call(Map config = [:]) {
                               chown -R jenkins.jenkins /localhome/jenkins/.ssh
                               echo \\"jenkins ALL=(ALL) NOPASSWD: ALL\\" > /etc/sudoers.d/jenkins
                               yum -y install epel-release
-                              if ! yum -y install openmpi CUnit fuse
+                              if ! yum -y install openmpi CUnit fuse           \
                                                   python36-PyYAML              \
                                                   python36-nose                \
                                                   python36-pip valgrind        \

--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -130,9 +130,9 @@ def call(Map config = [:]) {
                                                   python2-avocado-plugins-output-html \
                                                   python2-avocado-plugins-varianter-yaml-to-mux \
                                                   python-debuginfo             \
-                                                  python2-aexpect libcmocka    \
-                                                  python-pathlib python2-numpy \
-                                                  git golang-bin; then
+                                                  libcmocka python-pathlib     \
+                                                  python2-numpy git            \
+                                                  golang-bin; then
                                   rc=\\${PIPESTATUS[0]}
                                   for file in /etc/yum.repos.d/*.repo; do
                                       echo \\"---- \\$file ----\\"


### PR DESCRIPTION
It was only ever needed for Avocodo's expect module but we don't
use that any more.