### PR TITLE
CORCI-619 Make the link in comment e-mails point to the Details link

### DIFF
--- a/vars/stepResult.groovy
+++ b/vars/stepResult.groovy
@@ -90,11 +90,16 @@ def call(Map config= [:]) {
            if (config['result'] == "ABORTED" ||
                config['result'] == "UNSTABLE" ||
                config['result'] == "FAILURE") {
+                def comment_url = env.BUILD_URL + "display/redirect"
+
+                if (log_url) {
+                    comment_url = log_url
+                }
+
                 pullRequest.comment("Test stage ${config.name}" +
                                     " completed with status " +
                                     "${config.result}" +
-                                    ".  " + env.BUILD_URL +
-                                    "display/redirect")
+                                    ".  " + comment_url)
             }
 
             def result = config['result']


### PR DESCRIPTION
Now that we have changed the Details link on GitHub commit status to
point at the console log for the stage, update the comments to point
to the same link instead of Blue Ocean.