### PR TITLE
CORCI-539 build: provisionNodes fix

### DIFF
--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -108,10 +108,16 @@ def call(Map config = [:]) {
         error "One or more nodes failed to provision!"
       }
     }
+
     // Prepare the node for daos/cart testing
-    def provision_script = '''set -ex
-                              groupadd -g 1101 jenkins || true
-                              useradd -b /localhome -g 1101 -u 1101 jenkins || true
+    def provision_script = "set -ex\n" +
+                           "my_uid=" + env.UID + "\n" +
+                           '''if ! grep ":$my_uid:" /etc/group; then
+                                groupadd -g $my_uid jenkins
+                              fi
+                              if ! grep ":$my_uid:$my_uid:" /etc/passwd; then
+                                useradd -b /localhome -g $my_uid -u $my_uid jenkins
+                              fi
                               mkdir -p /localhome/jenkins/.ssh
                               cat /tmp/ci_key.pub >> /localhome/jenkins/.ssh/authorized_keys
                               mv /tmp/ci_key.pub /localhome/jenkins/.ssh/id_rsa.pub

--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -112,11 +112,11 @@ def call(Map config = [:]) {
     // Prepare the node for daos/cart testing
     def provision_script = "set -ex\n" +
                            "my_uid=" + env.UID + "\n" +
-                           '''if ! grep ":$my_uid:" /etc/group; then
-                                groupadd -g $my_uid jenkins
+                           '''if ! grep ":\\$my_uid:" /etc/group; then
+                                groupadd -g \\$my_uid jenkins
                               fi
-                              if ! grep ":$my_uid:$my_uid:" /etc/passwd; then
-                                useradd -b /localhome -g $my_uid -u $my_uid jenkins
+                              if ! grep ":\\$my_uid:\\$my_uid:" /etc/passwd; then
+                                useradd -b /localhome -g \\$my_uid -u \\$my_uid jenkins
                               fi
                               mkdir -p /localhome/jenkins/.ssh
                               cat /tmp/ci_key.pub >> /localhome/jenkins/.ssh/authorized_keys

--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -110,8 +110,8 @@ def call(Map config = [:]) {
     }
     // Prepare the node for daos/cart testing
     def provision_script = '''set -ex
-                              groupadd -g 1101 jenkins
-                              useradd -b /localhome -g 1101 -u 1101 jenkins
+                              groupadd -g 1101 jenkins || true
+                              useradd -b /localhome -g 1101 -u 1101 jenkins || true
                               mkdir -p /localhome/jenkins/.ssh
                               cat /tmp/ci_key.pub >> /localhome/jenkins/.ssh/authorized_keys
                               mv /tmp/ci_key.pub /localhome/jenkins/.ssh/id_rsa.pub
@@ -147,7 +147,8 @@ def call(Map config = [:]) {
                               if [ ! -e /usr/bin/python3 ] &&
                                  [ -e /usr/bin/python3.6 ]; then
                                   ln -s python3.6 /usr/bin/python3
-                              fi'''
+                              fi
+                              sync'''
     def rc = 0
     rc = sh(script: 'set -x; rm -f ci_key*; ssh-keygen -N "" -f ci_key;' +
                     ' pdcp -R ssh -l root -w ' + nodeString +


### PR DESCRIPTION
ProvisionNodes needs to be able to be called multiple times in a step.

The Jenkins account being added to the CI nodes may already exist.

Need to sync the file system after provisioning to make sure data
persists after a power cycle.

Signed-off-by: John.E.Malmberg <john.e.malmberg@intel.com>