### PR TITLE
DAOS-623 build: Fix the filename from daos_m to daos

### DIFF
--- a/vars/sconsBuild.groovy
+++ b/vars/sconsBuild.groovy
@@ -134,7 +134,7 @@ def call(Map config = [:]) {
     if (config['clean']) {
         clean_files = config['clean']
     }
-    clean_files += ' install build {daos_m,iof,cart-Linux}.conf'
+    clean_files += ' install build {daos,iof,cart-Linux}.conf'
     def clean_cmd = "scons -c ${sconstruct}\n"
     if (clean_files) {
         clean_cmd += "rm -rf ${clean_files}\n"

--- a/vars/sconsBuild.groovy
+++ b/vars/sconsBuild.groovy
@@ -134,7 +134,7 @@ def call(Map config = [:]) {
     if (config['clean']) {
         clean_files = config['clean']
     }
-    clean_files += ' install build {daos,iof,cart-Linux}.conf'
+    clean_files += ' install build {daos_m,daos,iof,cart-Linux}.conf'
     def clean_cmd = "scons -c ${sconstruct}\n"
     if (clean_files) {
         clean_cmd += "rm -rf ${clean_files}\n"


### PR DESCRIPTION
We recently removed the _m from the config file so the cleanup
needs to remove the new file instead.