### PR TITLE
CORCI-734 build: Add publishToRepository step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,64 @@
+#!/usr/bin/env groovy
+// Copyright (c) 2018 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+@Library(value="pipeline-lib@corci-734") _
+
+pipeline {
+    agent none
+
+    stages {
+        stage('publishToRepository tests') {
+            agent {
+                dockerfile {
+                    filename 'docker/Dockerfile.centos.7'
+                    label 'docker_runner'
+                    additionalBuildArgs  '--build-arg UID=$(id -u)'
+                }
+            }
+            steps {
+                // Populate an artifact directory
+                copyArtifacts projectName: '/daos-stack/libfabric/master',
+                              filter: 'artifacts/centos7/**',
+                              target: 'artifact'
+                publishToRepository(
+                    product: 'zzz_pl-' + env.BRANCH_NAME + '_' + env.BUILD_ID,
+                    format: 'yum',
+                    maturity: 'test',
+                    tech: 'el7',
+                    repo_dir: 'artifact/artifacts/centos7',
+                    download_dir: 'artifact/download',
+                    test: true)
+            }
+            post {
+                unsuccessful {
+                    daosStackNotifyStatus description: env.STAGE_NAME,
+                                          context: 'test/' + env.STAGE_NAME,
+                                          status: 'FAILURE'
+                }
+                success {
+                    daosStackNotifyStatus description: env.STAGE_NAME,
+                                          context: 'test/' + env.STAGE_NAME,
+                                          status: 'SUCCESS'
+                }
+            }
+        }
+    }
+}

--- a/docker/Dockerfile.centos.7
+++ b/docker/Dockerfile.centos.7
@@ -1,0 +1,32 @@
+#
+# Copyright 2018-2019, Intel Corporation
+#
+# 'recipe' for Docker to build an RPM
+#
+
+# Pull base image
+FROM centos:7
+MAINTAINER daos-stack <daos@daos.groups.io>
+
+# use same UID as host and default value of 1000 if not specified
+ARG UID=1000
+
+# Update distribution
+#Nothing to do for CentOS
+
+# Install basic tools
+RUN yum install -y epel-release
+RUN yum install -y mock make rpm-build curl createrepo rpmlint redhat-lsb-core \
+                   git
+
+# Add build user (to keep rpmbuild happy)
+ENV USER build
+ENV PASSWD build
+RUN useradd -u $UID -ms /bin/bash $USER
+RUN echo "$USER:$PASSWD" | chpasswd
+# add the user to the mock group so it can run mock
+RUN usermod -a -G mock $USER
+
+# mock in Docker needs to use the old-chroot option
+RUN grep use_nspawn || \
+    echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg

--- a/vars/daosStackNotifyStatus.groovy
+++ b/vars/daosStackNotifyStatus.groovy
@@ -1,0 +1,33 @@
+// vars/daosStackNotifiyStatus.groovy
+
+/**
+ * run.groovy
+ *
+ * Wrapper for daosStackNotifyStatusSystem.
+ * 
+ * The daosStacknotifyStatusSystem must be provided as a shared
+ * groovy library local to the running Jenkins for this routine.
+ *
+ * If it is not provided this routine will not do anything.
+ *
+ * This is to allow re-using the Jenkinsfiles and pipeline-lib files for
+ * other jenkins environments.
+ *
+ * @param config Map of parameters passed
+ * @return none
+ *
+ * The config[] parameters are the githubNotify step parameters.
+ * If you are using a different type of status notification, your
+ * notifyStatusSystem routine will need to translate them.
+ */
+
+def call(Map config = [:]) {
+
+    try {
+        return daosStackNotifyStatusSystem(config)
+    } catch (java.lang.NoSuchMethodError e) {
+        println('Could not find a daosStackNotifySystem step in' +
+                ' a shared groovy library')
+        return
+    }
+}

--- a/vars/publishToRepository.groovy
+++ b/vars/publishToRepository.groovy
@@ -1,0 +1,46 @@
+// vars/publishToRepository.groovy
+
+/**
+ * run.groovy
+ *
+ * Wrapper for publishToRepositorySystem.
+ * 
+ * The publishToRepositorySystem must be provided as a shared
+ * groovy library local to the running Jenkins for this routine.
+ *
+ * If it is not provided this routine will not do anything.
+ *
+ *
+ * @param config Map of parameters passed
+ * @return none
+ *
+ * config['arch']     Architecture, default 'x86_64'.
+ * config['maturity'] Maturity level: eg: 'stable'|'dev'|'test'.
+ *                    Default 'test'.
+ * config['product']  Name of product.
+ * config['repo_dir'] Directory to post artifacts from.
+ * config['tech']     Distro/version code for reposiory eg: 'el7'
+ * config['test']     Test by creating a temporary repo and then deleting it.
+ *                    default false.  Used to unit test this step.
+ * config['type']     Type of repository.  Default 'hosted'.
+ * config['download_dir'] If present, download the artifacts after the upload
+ *                        to validate.
+ *                        The publishToRepositorySystem step should dowload
+ *                        the artifacts back to this directory and fail the
+ *                        step if the contents differ.
+ */
+
+def call(Map config = [:]) {
+    if (env.REPOSITORY_URL == null) {
+        println('No REPOSITORY_URL environment variable configured.')
+        return
+    }
+    try {
+        return publishToRepositorySystem(config)
+    } catch (java.lang.NoSuchMethodError e) {
+        println('A REPOSITORY_URL environment variable was configured.')
+        println('Could not find a publishToRepositorySystem step in' +
+                ' a shared groovy library')
+        return
+    }
+}


### PR DESCRIPTION
Add a publishToRepository step to the public pipeline-lib as a wrapper
for an optional system provided step that handles the actual repository
operations.  This will eventually allow other Jenkins systems to use
our jenkinsfiles and pipeline-lib repository.

Signed-off-by: John.E.Malmberg <john.e.malmberg@intel.com>