### PR TITLE
Don't try to grep missing files

### DIFF
--- a/vars/runTest.groovy
+++ b/vars/runTest.groovy
@@ -82,10 +82,10 @@ def call(Map config = [:]) {
         status = "FAILURE"
     } else if (rc == 0) {
         if (config['junit_files'] != null) {
-            if (sh(script: "grep \"<error \" ${config.junit_files}",
+            if (sh(script: "junit_files=$(ls ${config.junit_files} || true); if [ -n "$junit_files" ]; then grep \"<error \" $junit_files; fi",
                    returnStatus: true) == 0) {
                 status = "FAILURE"
-            } else if (sh(script: "grep \"<failure \" ${config.junit_files}",
+            } else if (sh(script: "junit_files=$(ls ${config.junit_files} || true); if [ -n "$junit_files" ]; then grep \"<failure \" $junit_files; fi",
                           returnStatus: true) == 0) {
                 status = "UNSTABLE"
             } else {


### PR DESCRIPTION
When the junit files are missing, the `grep` of them (for errors and failures) returns a false negative result.  This results in the test being considered a pass when junit results even failed to be produced.

So make sure there are junit files to process before accepting the return status of `grep` on them since `grep` return status on them is the same when they are missing and when they contain no errors or failures.