### PR TITLE
CORCI-786 build: Allow rpmlint checks to fail.

### DIFF
--- a/vars/packageBuildingPipeline.groovy
+++ b/vars/packageBuildingPipeline.groovy
@@ -98,9 +98,11 @@ def call(Map pipeline_args) {
                             }
                         }
                         steps {
-                            sh 'make ' +
-                               pipeline_args.get('make args', '') +
-                               ' rpmlint'
+                            sh script: 'make ' +
+                                       pipeline_args.get('make args', '') +
+                                       ' rpmlint',
+                               returnStatus: !pipeline_args.get('rpmlint_check',
+                                                                 true)
                         }
                     }
                     stage('Check Packaging') {


### PR DESCRIPTION
vars/packageBuildingPipeline.groovy:
  The Slurm and Meson pckages currently do not pass lint.
  This allows a Jenkinsfile to supresss the lint checks.

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>