### PR TITLE
CORCI-788 build: Fix collection of rpm failures

### DIFF
--- a/vars/packageBuildingPipeline.groovy
+++ b/vars/packageBuildingPipeline.groovy
@@ -179,7 +179,8 @@ def call(Map pipeline_args) {
                             unsuccessful {
                                 sh label: "Collect artifacts",
                                    script: '''mockroot=/var/lib/mock/epel-7-x86_64
-                                              cat mockroot/results/{root,build}.log
+                                              ls -l $mockroot/result/
+                                              cat $mockroot/result/{root,build}.log
                                               artdir=$PWD/artifacts/centos7
                                               cp -af _topdir/SRPMS $artdir
                                               (cd $mockroot/result/ &&

--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -277,6 +277,7 @@ EOF'''
               'https://copr-be.cloud.fedoraproject.org/results/jhli' +
               '/ipmctl/pubkey.gpg'
       provision_script += '''\nrm -f /etc/profile.d/openmpi.sh
+                               rm -f /tmp/daos_control.log
                                yum -y erase metabench mdtest simul IOR compat-openmpi16
                                yum -y install epel-release
                                if ! yum -y install CUnit fuse python36-PyYAML   \


### PR DESCRIPTION
Fix collection of CentOS 7 mock rpm build failures.

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>