### PR TITLE
CORCI-792 build: Skip snapshot for non-VM

### DIFF
--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -56,6 +56,15 @@ def call(Map config = [:]) {
       return node_cnt
   }
 
+  // corci-792 assist code.
+  // corci-792 will convert the VM in a physical CI allocation to be
+  // a physical node, so we want to skip the snapshot restore when
+  // the only node is not a VM.
+  if (config['snapshot'] && (config['NODELIST'].indexOF('vm') < 0)) {
+    println "Skipping re-provisioning snapshot for physical nodes."
+    return 0
+  }
+
   checkoutScm url: 'git@gitlab.hpdd.intel.com:lab/ci-node-mgmt.git',
                                   checkoutDir: 'jenkins',
                                   credentialsId: 'daos-special-read'

--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -60,7 +60,7 @@ def call(Map config = [:]) {
   // corci-792 will convert the VM in a physical CI allocation to be
   // a physical node, so we want to skip the snapshot restore when
   // the only node is not a VM.
-  if (config['snapshot'] && (config['NODELIST'].indexOF('vm') < 0)) {
+  if (config['snapshot'] && (config['NODELIST'].indexOf('vm') < 0)) {
     println "Skipping re-provisioning snapshot for physical nodes."
     return 0
   }


### PR DESCRIPTION
Skip restoring a snapshot if the only system in the request
for a snapshot restore is not a VM.

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>