### PR TITLE
CORCI-819 build: Allow bootstrap of RPMs

### DIFF
--- a/vars/packageBuildingPipelineDAOS.groovy
+++ b/vars/packageBuildingPipelineDAOS.groovy
@@ -631,7 +631,7 @@ def call(Map pipeline_args) {
                                           git checkout ''' + pipeline_args.get('daos_test_branch',
                                                                                'origin/master') + '''
                                           git submodule update --init
-                                          if make PR_REPOS="''' + env.JOB_NAME.split('/')[1] +
+                                          if ! make PR_REPOS="''' + env.JOB_NAME.split('/')[1] +
                                                '@' + env.BRANCH_NAME + ':' + env.BUILD_NUMBER +
                                                ' ' + pipeline_args.get('test_repos', '') + '''" \
                                                CHROOT_NAME=epel-7-x86_64                        \

--- a/vars/packageBuildingPipelineDAOS.groovy
+++ b/vars/packageBuildingPipelineDAOS.groovy
@@ -631,11 +631,14 @@ def call(Map pipeline_args) {
                                           git checkout ''' + pipeline_args.get('daos_test_branch',
                                                                                'origin/master') + '''
                                           git submodule update --init
-                                          make PR_REPOS="''' + env.JOB_NAME.split('/')[1] +
+                                          if make PR_REPOS="''' + env.JOB_NAME.split('/')[1] +
                                                '@' + env.BRANCH_NAME + ':' + env.BUILD_NUMBER +
                                                ' ' + pipeline_args.get('test_repos', '') + '''" \
                                                CHROOT_NAME=epel-7-x86_64                        \
-                                               -C utils/rpms chrootbuild'''
+                                               -C utils/rpms chrootbuild; then
+                                            grep 'No matching package to install'               \
+                                                 /var/lib/mock/epel-7-x86_64/result/root.log
+                                            fi'''
                         }
                         post {
                             always {
@@ -676,11 +679,14 @@ def call(Map pipeline_args) {
                                           git checkout ''' + pipeline_args.get('daos_test_branch',
                                                                                'origin/master') + '''
                                           git submodule update --init
-                                          make PR_REPOS="''' + env.JOB_NAME.split('/')[1] +
+                                          if ! make PR_REPOS="''' + env.JOB_NAME.split('/')[1] +
                                                '@' + env.BRANCH_NAME + ':' + env.BUILD_NUMBER +
                                                ' ' + pipeline_args.get('test_repos', '') + '''" \
                                                CHROOT_NAME=opensuse-leap-15.1-x86_64            \
-                                               -C utils/rpms chrootbuild'''
+                                               -C utils/rpms chrootbuild; then
+                                            grep 'No matching package to install'               \
+                                                 /var/lib/mock/opensuse-leap-15.1-x86_64/result/root.log
+                                          fi'''
                         }
                         post {
                             always {

--- a/vars/packageBuildingPipelineDAOS.groovy
+++ b/vars/packageBuildingPipelineDAOS.groovy
@@ -636,10 +636,10 @@ def call(Map pipeline_args) {
                                                ' ' + pipeline_args.get('test_repos', '') + '''" \
                                                CHROOT_NAME=epel-7-x86_64                        \
                                                -C utils/rpms chrootbuild; then
+                                            # We need to allow failures from missing other packages
+                                            # we build for creating an initial set of packages
                                             grep 'No matching package to install'               \
                                                  /var/lib/mock/epel-7-x86_64/result/root.log
-                                          else
-                                            exit ${PIPESTATUS[0]}
                                           fi'''
                         }
                         post {
@@ -688,8 +688,8 @@ def call(Map pipeline_args) {
                                                -C utils/rpms chrootbuild; then
                                             grep 'No matching package to install'               \
                                                  /var/lib/mock/opensuse-leap-15.1-x86_64/result/root.log
-                                          else
-                                            exit ${PIPESTATUS[0]}
+                                            # We need to allow failures from missing other packages
+                                            # we build for creating an initial set of packages
                                           fi'''
                         }
                         post {

--- a/vars/packageBuildingPipelineDAOS.groovy
+++ b/vars/packageBuildingPipelineDAOS.groovy
@@ -631,14 +631,16 @@ def call(Map pipeline_args) {
                                           git checkout ''' + pipeline_args.get('daos_test_branch',
                                                                                'origin/master') + '''
                                           git submodule update --init
-                                          if ! make PR_REPOS="''' + env.JOB_NAME.split('/')[1] +
+                                          if make PR_REPOS="''' + env.JOB_NAME.split('/')[1] +
                                                '@' + env.BRANCH_NAME + ':' + env.BUILD_NUMBER +
                                                ' ' + pipeline_args.get('test_repos', '') + '''" \
                                                CHROOT_NAME=epel-7-x86_64                        \
                                                -C utils/rpms chrootbuild; then
                                             grep 'No matching package to install'               \
                                                  /var/lib/mock/epel-7-x86_64/result/root.log
-                                            fi'''
+                                          else
+                                            exit ${PIPESTATUS[0]}
+                                          fi'''
                         }
                         post {
                             always {
@@ -686,6 +688,8 @@ def call(Map pipeline_args) {
                                                -C utils/rpms chrootbuild; then
                                             grep 'No matching package to install'               \
                                                  /var/lib/mock/opensuse-leap-15.1-x86_64/result/root.log
+                                          else
+                                            exit ${PIPESTATUS[0]}
                                           fi'''
                         }
                         post {


### PR DESCRIPTION
File: vars/packageBuildingPipelineDAOS.groovy
When boot-strapping a new Jenkins the test stage can fail when not all
the RPMs are present.

Ignore test failures caused by missing packages.

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>