### PR TITLE
Escape slashes when building URLs

### DIFF
--- a/vars/stepResult.groovy
+++ b/vars/stepResult.groovy
@@ -39,9 +39,10 @@ def call(Map config= [:]) {
             def jsonSlurperClassic = new JsonSlurperClassic()
 
             def h = new com.intel.doGetHttpRequest()
-            resp = h.doGetHttpRequest(env.JOB_URL - ~/job\/[^\/]*\/$/ +
-                "/view/change-requests/job/${env.BRANCH_NAME}/" +
-                "${env.BUILD_ID}/wfapi/describe");
+            resp = h.doGetHttpRequest(env.JOB_URL - ~/\/job\/[^\/]*\/$/ +
+                "/view/change-requests/job/" +
+                env.BRANCH_NAME.replaceAll('/', '%252F') +
+                "/${env.BUILD_ID}/wfapi/describe");
 
             def job = jsonSlurperClassic.parseText(resp)
             assert job instanceof Map


### PR DESCRIPTION
Since we have branch names with / in them, when building a URL with
a branch name in it, we must escape the /s.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>