### PR TITLE
CORCI-768 build: Add CI profile support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2018-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -26,6 +26,7 @@
 // is landed, both PR branches can be deleted.
 
 // @Library(value="pipeline-lib@my_pr_branch") _
+@Library(value="pipeline-lib@corci-768") _
 
 pipeline {
     agent { label 'lightweight' }
@@ -90,6 +91,7 @@ pipeline {
                 steps {
                     provisionNodes NODELIST: env.NODELIST,
                                    distro: 'el7',
+                                   profile: 'ci',
                                    node_count: 1,
                                    snapshot: true,
                                    inst_rpms: "slurm slurm-example-configs" +
@@ -118,11 +120,10 @@ pipeline {
                     }
                 }
             } //stage('provisionNodes_with_slurm_el7')
-            stage('provisionNodes_with_slurm_sles12') {
+            stage('provisionNodes_with_slurm_leap15') {
                 when {
                     beforeAgent true
                     allOf {
-                        expression { false }
                         expression { env.NO_CI_TESTING != "true" }
                     }
                 }
@@ -131,7 +132,8 @@ pipeline {
                 }
                 steps {
                     provisionNodes NODELIST: env.NODELIST,
-                                   distro: 'sles12sp3',
+                                   distro: 'opensuse15',
+                                   profile: 'ci',
                                    node_count: 1,
                                    snapshot: true,
                                    inst_rpms: "slurm ipmctl"
@@ -157,7 +159,7 @@ pipeline {
                             status: 'SUCCESS')
                     }
                 }
-            } //stage('provisionNodes_with_slurm_sles12')
+            } //stage('provisionNodes_with_slurm_leap15')
           } // parallel
         } // stage('Test')
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
                 steps {
                     provisionNodes NODELIST: env.NODELIST,
                                    distro: 'el7',
-                                   profile: 'ci',
+                                   profile: 'daos_ci',
                                    node_count: 1,
                                    snapshot: true,
                                    inst_rpms: "slurm slurm-example-configs" +
@@ -133,7 +133,7 @@ pipeline {
                 steps {
                     provisionNodes NODELIST: env.NODELIST,
                                    distro: 'opensuse15',
-                                   profile: 'ci',
+                                   profile: 'daos_ci',
                                    node_count: 1,
                                    snapshot: true,
                                    inst_rpms: "slurm ipmctl"

--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -100,7 +100,8 @@ def call(Map config = [:]) {
   def repository_g = ''
   def repository_l = ''
   def distro_type = 'el'
-  if (distro.startsWith("sles") || distro.startsWith("leap")) {
+  if (distro.startsWith("sles") || distro.startsWith("leap") ||
+      distro.startsWith("opensuse")) {
       distro_type = 'suse'
   }
   def gpg_key_urls = []
@@ -125,15 +126,6 @@ def call(Map config = [:]) {
         if (env.DAOS_STACK_EL_7_LOCAL_REPO != null) {
             repository_l = env.REPOSITORY_URL + env.DAOS_STACK_EL_7_LOCAL_REPO
         }
-    } else if (distro.startsWith("sles12")) {
-        if (env.DAOS_STACK_SLES_12_GROUP_REPO != null) {
-            repository_g = env.REPOSITORY_URL +
-                env.DAOS_STACK_SLES_12_GROUP_REPO
-        }
-        if (env.DAOS_STACK_SLES_12_LOCAL_REPO != null) {
-            repository_l = env.REPOSITORY_URL +
-                env.DAOS_STACK_SLES_12_LOCAL_REPO
-        }
     } else if (distro.startsWith("sles15")) {
         if (env.DAOS_STACK_SLES_15_GROUP_REPO != null) {
             repository_g = env.REPOSITORY_URL +
@@ -143,7 +135,8 @@ def call(Map config = [:]) {
             repository_g = env.REPOSITORY_URL +
                 env.DAOS_STACK_SLES_15_LOCAL_REPO
         }
-    }  else if (distro.startsWith("leap15")) {
+    }  else if (distro.startsWith("leap15") ||
+                distro.startsWith("opensuse15")) {
         if (env.DAOS_STACK_LEAP_15_GROUP_REPO != null) {
             repository_g = env.REPOSITORY_URL +
                 env.DAOS_STACK_LEAP_15_GROUP_REPO
@@ -241,6 +234,7 @@ EOF'''
                           if ! grep \\":\\$my_uid:\\" /etc/group; then
                             groupadd -g \\$my_uid jenkins
                           fi
+                          mkdir -p /localhome
                           if ! grep \\":\\$my_uid:\\$my_uid:\\" /etc/passwd; then
                             useradd -b /localhome -g \\$my_uid -u \\$my_uid jenkins
                           fi
@@ -275,7 +269,7 @@ EOF'''
                             ' openpa pmix protobuf-c spdk libfabric libpmem' +
                             ' libpmemblk munge-libs munge slurm' +
                             ' slurm-example-configs slurmctld slurm-slurmmd'
-      provision_script +=   '\nyum -y install yum-utils'
+      provision_script +=   '\nyum -y install yum-utils ed nfs-utils'
       if (repository_g != '') {
         def repo_file = repository_g.substring(
                             repository_g.lastIndexOf('/') + 1,
@@ -311,9 +305,6 @@ EOF'''
       gpg_key_urls.each { gpg_url ->
         provision_script += '\nrpm --import ' + gpg_url
       }
-      provision_script += '\nrpm --import ' +
-              'https://copr-be.cloud.fedoraproject.org/results/jhli' +
-              '/ipmctl/pubkey.gpg'
       provision_script += '''\nrm -f /etc/profile.d/openmpi.sh
                                rm -f /tmp/daos_control.log
                                yum -y erase metabench mdtest simul IOR compat-openmpi16
@@ -328,7 +319,7 @@ EOF'''
                                                    libcmocka python-pathlib     \
                                                    python2-numpy git            \
                                                    python2-clustershell         \
-                                                   golang-bin'''
+                                                   golang-bin ipmctl'''
       if (inst_rpms) {
          provision_script += ' ' + inst_rpms
       }
@@ -349,13 +340,6 @@ EOF'''
                               ln -s python3.6 /usr/bin/python3
                           fi'''
     } else if (distro_type == "suse") {
-      // Needed for sles-12.3/leap-42.3 only
-      provision_script += '\nrpm --import https://download.opensuse.org/' +
-                                 'repositories/science:/HPC/' +
-                                 'openSUSE_Leap_42.3/repodata/repomd.xml.key'
-      provision_script += '\nrpm --import https://download.opensuse.org/' +
-                                 'repositories/home:/jhli/SLE_15/' +
-                                 'repodata/repomd.xml.key'
       if (repository_g != '') {
         provision_script += '\nzypper --non-interactive ar -f ' +
                             repository_g + ' daos-stack-group-repo'
@@ -372,13 +356,14 @@ EOF'''
       }
       if (inst_repos) {
         provision_script +=   '\n' + iterate_repos +
-                            '''\n    zypper --non-interactive ar --gpgcheck-allow-unsigned -f ''' + env.JENKINS_URL + '''job/daos-stack/job/\\\${repo}/job/\\\${branch}/\\\${build_number}/artifact/artifacts/sles12.3/ \\\$repo
+                            '''\n    zypper --non-interactive ar --gpgcheck-allow-unsigned -f ''' + env.JENKINS_URL + '''job/daos-stack/job/\\\${repo}/job/\\\${branch}/\\\${build_number}/artifact/artifacts/leap15/ \\\$repo
                                  done'''
       }
       provision_script += '\nzypper --non-interactive' +
                           ' --gpg-auto-import-keys --no-gpg-checks ref'
+      provision_script += '\nzypper --non-interactive in ed nfs-client ipmctl '
       if (inst_rpms) {
-        provision_script += '\nzypper --non-interactive in ' + inst_rpms
+        provision_script += inst_rpms
       }
     } else {
         error("Don't know how to handle repos for distro: \"" + distro + "\"")


### PR DESCRIPTION
Add CI profile support for el7 and sles15, opensuse15.
Remove SLES-12 support from provisionNodes.

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>