### PR TITLE
Fix repo file name when branch has a / in it

### DIFF
--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -312,7 +312,7 @@ EOF'''
       if (inst_repos) {
         provision_script += '\n' + iterate_repos +
                             '''\nyum-config-manager --add-repo=''' + env.JENKINS_URL + '''job/daos-stack/job/\\\${repo}/job/\\\${branch}/\\\${build_number}/artifact/artifacts/centos7/
-                               echo \\"gpgcheck = False\\" >> /etc/yum.repos.d/*.hpdd.intel.com_job_daos-stack_job_\\\${repo}_job_\\\${branch}_\\\${build_number}_artifact_artifacts_centos7_.repo
+                               echo \\"gpgcheck = False\\" >> /etc/yum.repos.d/*.hpdd.intel.com_job_daos-stack_job_\\\${repo}_job_\\\${branch//\\\//_}_\\\${build_number}_artifact_artifacts_centos7_.repo
                            done'''
       }
       if (inst_rpms) {

--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -312,7 +312,7 @@ EOF'''
       if (inst_repos) {
         provision_script += '\n' + iterate_repos +
                             '''\nyum-config-manager --add-repo=''' + env.JENKINS_URL + '''job/daos-stack/job/\\\${repo}/job/\\\${branch}/\\\${build_number}/artifact/artifacts/centos7/
-                               echo \\"gpgcheck = False\\" >> /etc/yum.repos.d/*.hpdd.intel.com_job_daos-stack_job_\\\${repo}_job_\\\${branch//\\\//_}_\\\${build_number}_artifact_artifacts_centos7_.repo
+                               echo \\"gpgcheck = False\\" >> /etc/yum.repos.d/*.hpdd.intel.com_job_daos-stack_job_\\\${repo}_job_\\\${branch//\\//_}_\\\${build_number}_artifact_artifacts_centos7_.repo
                            done'''
       }
       if (inst_rpms) {


### PR DESCRIPTION

It needs to be escaped to _ since filenames cannot have / in them.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>