### PR TITLE
CORCI-887 build: Matrix parameters are strings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,7 +157,7 @@ pipeline {
                     provisionNodes NODELIST: env.NODELIST,
                                    distro: 'el7',
                                    profile: 'daos_ci',
-                                   node_count: 1,
+                                   node_count: '1',
                                    snapshot: true,
                                    inst_repos: "daos@release/0.9"
                     runTest script: '''NODE=${NODELIST%%,*}
@@ -180,7 +180,7 @@ pipeline {
                             status: 'SUCCESS')
                     }
                 }
-            } //stage('provisionNodes with slurm EL7')
+            } //stage('provisionNodes withl release/0.9 Repo')
             stage('provisionNodes with master Repo') {
                 when {
                     beforeAgent true
@@ -216,7 +216,7 @@ pipeline {
                             status: 'SUCCESS')
                     }
                 }
-            } //stage('provisionNodes with slurm EL7')
+            } // stage('provisionNodes with master Repo')
             stage('provisionNodes with slurm EL7') {
                 when {
                     beforeAgent true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ pipeline {
                     }
                 }
             } //stage('publishToRepository tests')
-            stage('provisionNodes withl release/0.9 Repo') {
+            stage('provisionNodes with release/0.9 Repo') {
                 when {
                     beforeAgent true
                     expression { env.NO_CI_TESTING != "true" }
@@ -180,7 +180,7 @@ pipeline {
                             status: 'SUCCESS')
                     }
                 }
-            } //stage('provisionNodes withl release/0.9 Repo')
+            } //stage('provisionNodes with release/0.9 Repo')
             stage('provisionNodes with master Repo') {
                 when {
                     beforeAgent true


### PR DESCRIPTION
Matrix parameters which need to be passed to node provisioning
are strings, so need to be used as int.

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>