### PR TITLE
Don't install fuse in post-provisioning

### DIFF
--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -236,16 +236,16 @@ EOF'''
                              rm -f /tmp/daos_control.log
                              yum -y erase metabench mdtest simul IOR compat-openmpi16
                              yum -y install epel-release
-                             if ! yum -y install CUnit fuse python36-PyYAML   \
-                                                 python36-nose                \
-                                                 python36-pip valgrind        \
-                                                 python36-paramiko            \
-                                                 python2-avocado              \
-                                                 python2-avocado-plugins-output-html \
+                             if ! yum -y install CUnit python36-PyYAML                         \
+                                                 python36-nose                                 \
+                                                 python36-pip valgrind                         \
+                                                 python36-paramiko                             \
+                                                 python2-avocado                               \
+                                                 python2-avocado-plugins-output-html           \
                                                  python2-avocado-plugins-varianter-yaml-to-mux \
-                                                 libcmocka python-pathlib     \
-                                                 python2-numpy git            \
-                                                 python2-clustershell         \
+                                                 libcmocka python-pathlib                      \
+                                                 python2-numpy git                             \
+                                                 python2-clustershell                          \
                                                  golang-bin ipmctl ndctl'''
     if (inst_rpms) {
       provision_script += ' ' + inst_rpms


### PR DESCRIPTION
DAOS depends on it so no need to install it explicitly.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>