### PR TITLE
CORCI-922 build: Use $GIT_COMMIT as the default object to check out

### DIFF
--- a/vars/checkPatch.groovy
+++ b/vars/checkPatch.groovy
@@ -28,18 +28,15 @@ def call(Map config = [:]) {
       return
     }
 
+    // Get the project being checked's submodules
     checkoutScm withSubmodules: true
+
+    // Now checkout the code-review repo
     def branch = 'master'
     if (config['branch']) {
         branch = config['branch']
     }
 
-    def ignored_files="code_review/checkpatch.pl"
-    if (config['ignored_files']) {
-        ignored_files += ":" + config['ignored_files']
-    }
-
-    // Need the jenkins module to do linting
     checkoutScm url: 'https://github.com/daos-stack/code_review.git',
                 checkoutDir: 'code_review',
                 branch: branch
@@ -48,6 +45,11 @@ def call(Map config = [:]) {
                  description: env.STAGE_NAME,
                  context: "pre-build" + "/" + env.STAGE_NAME,
                  status: "PENDING"
+
+    def ignored_files="code_review/checkpatch.pl"
+    if (config['ignored_files']) {
+        ignored_files += ":" + config['ignored_files']
+    }
 
     int rc = 1
     def script = 'CHECKPATCH_IGNORED_FILES="' + ignored_files + '"' + \


### PR DESCRIPTION

scm.branches contains a branch name, not a commit.  That means that
on Replay, where you want to re-build an older build, scm will build
the branch tip, not the commit being Replayed.

Also in the case quick successive commits to a branch, again since
scm.branches contains the branch name, by the time the first of some
successive commits gets to the point of doing the checkout, the branch
tip might be a newer commit than that being built, in which case the
build ends up bulding a subsequent commit, not the one it should be.

Use $GIT_COMMIT to resolve this issue, as it should always point at
the specific commmit, no the branch tip.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>