### PR TITLE
Change Collect Artifacts step name

### DIFF
--- a/vars/packageBuildingPipeline.groovy
+++ b/vars/packageBuildingPipeline.groovy
@@ -188,7 +188,7 @@ def call(Map pipeline_args) {
                                                             allowEmptyArchive: true
                             }
                             unsuccessful {
-                                sh label: "Collect artifacts",
+                                sh label: "Build Log",
                                    script: '''mockroot=/var/lib/mock/epel-7-x86_64
                                               ls -l $mockroot/result/
                                               cat $mockroot/result/{root,build}.log
@@ -261,7 +261,7 @@ def call(Map pipeline_args) {
                                                             allowEmptyArchive: true
                             }
                             unsuccessful {
-                                sh label: "Collect artifacts",
+                                sh label: "Build Log",
                                    script: '''mockroot=/var/lib/mock/epel-8-x86_64
                                               ls -l $mockroot/result/
                                               cat $mockroot/result/{root,build}.log
@@ -336,7 +336,7 @@ def call(Map pipeline_args) {
                                                             allowEmptyArchive: true
                             }
                             unsuccessful {
-                                sh label: "Collect artifacts",
+                                sh label: "Build Log",
                                    script: '''mockroot=/var/lib/mock/sles-12.3-x86_64
                                               ls -l $mockroot/result/
                                               cat $mockroot/result/{root,build}.log
@@ -410,7 +410,7 @@ def call(Map pipeline_args) {
                                                             allowEmptyArchive: true
                             }
                             unsuccessful {
-                                sh label: "Collect artifacts",
+                                sh label: "Build Log",
                                    script: '''mockroot=/var/lib/mock/opensuse-leap-42.3-x86_64
                                               ls -l $mockroot/result/
                                               cat $mockroot/result/{root,build}.log
@@ -484,7 +484,7 @@ def call(Map pipeline_args) {
                                                             allowEmptyArchive: true
                             }
                             unsuccessful {
-                                sh label: "Collect artifacts",
+                                sh label: "Build Log",
                                    script: '''mockroot=/var/lib/mock/opensuse-leap-15.1-x86_64
                                               ls -l $mockroot/result/
                                               cat $mockroot/result/{root,build}.log

--- a/vars/packageBuildingPipelineDAOS.groovy
+++ b/vars/packageBuildingPipelineDAOS.groovy
@@ -241,7 +241,7 @@ def call(Map pipeline_args) {
                                                             allowEmptyArchive: true
                             }
                             unsuccessful {
-                                sh label: "Collect artifacts",
+                                sh label: "Build Log",
                                    script: '''mockroot=/var/lib/mock/epel-7-x86_64
                                               ls -l $mockroot/result/
                                               cat $mockroot/result/{root,build}.log
@@ -314,7 +314,7 @@ def call(Map pipeline_args) {
                                                             allowEmptyArchive: true
                             }
                             unsuccessful {
-                                sh label: "Collect artifacts",
+                                sh label: "Build Log",
                                    script: '''mockroot=/var/lib/mock/epel-8-x86_64
                                               ls -l $mockroot/result/
                                               cat $mockroot/result/{root,build}.log
@@ -390,7 +390,7 @@ def call(Map pipeline_args) {
                                                             allowEmptyArchive: true
                             }
                             unsuccessful {
-                                sh label: "Collect artifacts",
+                                sh label: "Build Log",
                                    script: '''mockroot=/var/lib/mock/sles-12.3-x86_64
                                               ls -l $mockroot/result/
                                               cat $mockroot/result/{root,build}.log
@@ -465,7 +465,7 @@ def call(Map pipeline_args) {
                                                             allowEmptyArchive: true
                             }
                             unsuccessful {
-                                sh label: "Collect artifacts",
+                                sh label: "Build Log",
                                    script: '''mockroot=/var/lib/mock/opensuse-leap-42.3-x86_64
                                               ls -l $mockroot/result/
                                               cat $mockroot/result/{root,build}.log
@@ -539,7 +539,7 @@ def call(Map pipeline_args) {
                                                             allowEmptyArchive: true
                             }
                             unsuccessful {
-                                sh label: "Collect artifacts",
+                                sh label: "Build Log",
                                    script: '''mockroot=/var/lib/mock/opensuse-leap-15.1-x86_64
                                               ls -l $mockroot/result/
                                               cat $mockroot/result/{root,build}.log
@@ -730,7 +730,8 @@ def call(Map pipeline_args) {
                         }
                         post {
                             always {
-                                sh 'cat /var/lib/mock/epel-7-x86_64/result/{root,build}.log'
+                                sh label: "Build Log",
+                                   script: 'cat /var/lib/mock/epel-7-x86_64/result/{root,build}.log'
                             }
                             cleanup {
                                 archiveArtifacts artifacts: 'test_artifacts/**',
@@ -779,7 +780,8 @@ def call(Map pipeline_args) {
                         }
                         post {
                             always {
-                                sh 'cat /var/lib/mock/opensuse-leap-15.1-x86_64/result/{root,build}.log'
+                                sh label: "Build Log",
+                                   script: 'cat /var/lib/mock/opensuse-leap-15.1-x86_64/result/{root,build}.log'
                             }
                             cleanup {
                                 archiveArtifacts artifacts: 'test_artifacts/**',


### PR DESCRIPTION

To Build Log to make it more clear that that's where the
build log can be viewed.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>