### PR TITLE
Resurrect publish_branch option

### DIFF
--- a/vars/publishToRepository.groovy
+++ b/vars/publishToRepository.groovy
@@ -14,21 +14,23 @@
  * @param config Map of parameters passed
  * @return none
  *
- * config['arch']         Architecture, default 'x86_64'.
- * config['maturity']     Maturity level: eg: 'stable'|'dev'|'test'.
- *                        Default 'test'.
- * config['product']      Name of product.
- * config['repo_dir']     Directory to post artifacts from.
- * config['tech']         Distro/version code for reposiory eg: 'el7'
- * config['test']         Test by creating a temporary repo and then deleting it.
- *                        default false.  Used to unit test this step.
- * config['type']         Type of repository.  Default 'hosted'.
- * config['download_dir'] If present, download the artifacts after the upload
- *                        to validate.
- *                        The publishToRepositorySystem step should dowload
- *                        the artifacts back to this directory and fail the
- *                        step if the contents differ.
-*/
+ * config['arch']           Architecture, default 'x86_64'.
+ * config['maturity']       Maturity level: eg: 'stable'|'dev'|'test'.
+ *                          Default 'test'.
+ * config['product']        Name of product.
+ * config['repo_dir']       Directory to post artifacts from.
+ * config['tech']           Distro/version code for reposiory eg: 'el7'
+ * config['test']           Test by creating a temporary repo and then deleting it.
+ *                          default false.  Used to unit test this step.
+ * config['type']           Type of repository.  Default 'hosted'.
+ * config['download_dir']   If present, download the artifacts after the upload
+ *                          to validate.
+ *                          The publishToRepositorySystem step should dowload
+ *                          the artifacts back to this directory and fail the
+ *                          step if the contents differ.
+ * config['publish_branch'] The branch to publish from.  Defaults to release/*
+                            and master.
+ */
 
 def call(Map config = [:]) {
     if (env.REPOSITORY_URL == null) {
@@ -36,11 +38,19 @@ def call(Map config = [:]) {
         return
     }
 
-    // Only publish on known landing (i.e. release) branches (unless testing)
-    if (!env.BRANCH_NAME.startsWith("release/") &&
-        env.BRANCH_NAME != 'master' &&
-        !config['test']) {
-        return
+    if (config['publish_branch']) {
+        // Don't publish from PRs (unless testing)
+        if (env.BRANCH_NAME != config['publish_branch'] && !config['test']) {
+            return
+        }
+    } else {
+        // Only publish on known landing (i.e. release) branches (unless testing)
+        if (!env.BRANCH_NAME.startsWith("release/") &&
+            env.BRANCH_NAME != 'master' &&
+            !config['test']) {
+                return
+            }
+        }
     }
 
     try {


### PR DESCRIPTION

We have repos that want to publish from other than the doas known
publishing branches.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>