### PR TITLE
Ignore a failure to unstash a valgrind stash

### DIFF
--- a/vars/valgrindReportPublish.groovy
+++ b/vars/valgrindReportPublish.groovy
@@ -35,7 +35,11 @@ def call(Map config = [:]) {
 
   int stash_cnt=0
   stashes.each {
-    unstash it
+    try {
+      unstash it
+      } catch(Exception ex) {
+         println("Ignoring failure to unstash ${it}.  Perhaps the stage was skipped?")
+      }
   }
 
   def ignore_failure = config.get('ignore_failure', false)


### PR DESCRIPTION

The stage for it might have been skipped.

Future enhancement is to tell valgrindReportPublish which stages were
run so that it can produce an error if a stash for a run stage was
missing.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>