### PR TITLE
CORCI-1011 unit-test: Abort the build on test failure/unstable result

### DIFF
--- a/vars/runTest.groovy
+++ b/vars/runTest.groovy
@@ -171,15 +171,15 @@ def call(Map config = [:]) {
                junit_files: config['junit_files'],
                ignore_failure: ignore_failure
 
-    if (status == 'FAILURE') {
-        def stage_status = 'FAILURE'
+    if (status != 'SUCCESS') {
         if (ignore_failure) {
-            stage_status = 'UNSTABLE'
-        }
-        catchError(stageResult: stage_status,
-                   buildResult: 'SUCCESS') {
-            error(env.STAGE_NAME + " failed: " + rc)
-        }
+            catchError(stageResult: 'UNSTABLE',
+                       buildResult: 'SUCCESS') {
+                error(env.STAGE_NAME + " failed: " + rc)
+            }
+	} else {
+	       error(env.STAGE_NAME + " failed: " + rc)
+	}
     }
 
 }


### PR DESCRIPTION
Change runTest() to propagate errors so that they stop the build from
advancing onto the next stage.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>