### PR TITLE
￼Revert some of "Don't truncate std{out,err} in JUnit results (#172)" 

### DIFF
--- a/vars/archiveArtifacts.groovy
+++ b/vars/archiveArtifacts.groovy
@@ -7,17 +7,17 @@
  *
  */
 
-void call(Map config = [:]) {
+def call(Map config = [:]) {
     // We really shouldn't even get here if $NO_CI_TESTING is true as the
     // when{} block for the stage should skip it entirely.  But we'll leave
     // this for historical purposes
-    String script = 'if [ "' + env.NO_CI_TESTING + '''" == 'true' ]; then
-                          exit 1
-                      fi
-                      if git show -s --format=%B | grep "^Skip-test: true"; then
-                          exit 1
-                      fi
-                      exit 0\n'''
+    def script = 'if [ "' + env.NO_CI_TESTING + '''" == 'true' ]; then
+                      exit 1
+                  fi
+                  if git show -s --format=%B | grep "^Skip-test: true"; then
+                      exit 1
+                  fi
+                  exit 0\n'''
     int rc = 0
     rc = sh(script: script, label: env.STAGE_NAME + '_archiveArtifacts',
             returnStatus: true)

--- a/vars/junit.groovy
+++ b/vars/junit.groovy
@@ -9,23 +9,23 @@
 
 
 
-void call(String testResults) {
+def call(String testResults) {
     Map config = [:]
     config['testResults'] = testResults
     call(config)
 }
 
-void call(Map config = [:]) {
+def call(Map config = [:]) {
     // We really shouldn't even get here if $NO_CI_TESTING is true as the
     // when{} block for the stage should skip it entirely.  But we'll leave
     // this for historical purposes
-    String script = 'if [ "' + env.NO_CI_TESTING + '''" == 'true' ]; then
-                          exit 1
-                      fi
-                      if git show -s --format=%B | grep "^Skip-test: true"; then
-                          exit 1
-                      fi
-                      exit 0'''
+    def script = 'if [ "' + env.NO_CI_TESTING + '''" == 'true' ]; then
+                      exit 1
+                  fi
+                  if git show -s --format=%B | grep "^Skip-test: true"; then
+                      exit 1
+                  fi
+                  exit 0\n'''
     int rc = 0
     rc = sh(script: script, label: env.STAGE_NAME + '_junit',
             returnStatus: true)

--- a/vars/publishValgrind.groovy
+++ b/vars/publishValgrind.groovy
@@ -7,17 +7,17 @@
  *
  */
 
-void call(Map config = [:]) {
+def call(Map config = [:]) {
     // We really shouldn't even get here if $NO_CI_TESTING is true as the
     // when{} block for the stage should skip it entirely.  But we'll leave
     // this for historical purposes
-    String script = 'if [ "' + env.NO_CI_TESTING + '''" == 'true' ]; then
-                        exit 1
-                    fi
-                    if git show -s --format=%B | grep "^Skip-test: true"; then
-                        exit 1
-                    fi
-                    exit 0\n'''
+    def script = 'if [ "' + env.NO_CI_TESTING + '''" == 'true' ]; then
+                      exit 1
+                  fi
+                  if git show -s --format=%B | grep "^Skip-test: true"; then
+                      exit 1
+                  fi
+                  exit 0\n'''
     int rc = 0
     rc = sh(script: script, label: env.STAGE_NAME + '_publishValgrind',
             returnStatus: true)

--- a/vars/runTest.groovy
+++ b/vars/runTest.groovy
@@ -7,7 +7,7 @@
  *
  */
 
-void call(Map config = [:]) {
+def call(Map config = [:]) {
   /**
    * runTest step method
    *
@@ -50,9 +50,9 @@ void call(Map config = [:]) {
     // github expectations at the same time to also include any Matrix
     // environment variables.
 
-    String context = config.get('context', 'test/' + env.STAGE_NAME)
-    String description = config.get('description', env.STAGE_NAME)
-    String flow_name = config.get('flow_name', env.STAGE_NAME)
+    def context = config.get('context', 'test/' + env.STAGE_NAME)
+    def description = config.get('description', env.STAGE_NAME)
+    def flow_name = config.get('flow_name', env.STAGE_NAME)
 
     dir('install') {
         deleteDir()
@@ -63,7 +63,7 @@ void call(Map config = [:]) {
         }
     }
 
-    boolean ignore_failure = false
+    def ignore_failure = false
     if (config['ignore_failure']) {
         ignore_failure = true
     }
@@ -75,27 +75,27 @@ void call(Map config = [:]) {
     // We really shouldn't even get here if $NO_CI_TESTING is true as the
     // when{} block for the stage should skip it entirely.  But we'll leave
     // this for historical purposes
-    String script = '''skipped=false
-                       if [ "''' + env.NO_CI_TESTING + '''" == 'true' ]; then
-                           skipped=true
-                       fi
-                       if git show -s --format=%B | grep "^Skip-test: true"; then
-                           skipped=true
-                       fi
-                       if ${skipped}; then
-                           # cart
-                           testdir1="install/Linux/TESTING/testLogs"
-                           testdir2="${testdir1}_valgrind"
-                           # daos
-                           testdir3="src/tests/ftest/avocado/job-results"
-                           mkdir -p "${testdir1}"
-                           mkdir -p "${testdir2}"
-                           mkdir -p "${testdir3}"
-                           touch "${testdir1}/skipped_tests"
-                           touch "${testdir2}/skipped_tests"
-                           touch "${testdir3}/skipped_tests"
-                           exit 0
-                       fi\n''' + config['script']
+    def script = '''skipped=false
+                    if [ "''' + env.NO_CI_TESTING + '''" == 'true' ]; then
+                        skipped=true
+                    fi
+                    if git show -s --format=%B | grep "^Skip-test: true"; then
+                        skipped=true
+                    fi
+                    if ${skipped}; then
+                        # cart
+                        testdir1="install/Linux/TESTING/testLogs"
+                        testdir2="${testdir1}_valgrind"
+                        # daos
+                        testdir3="src/tests/ftest/avocado/job-results"
+                        mkdir -p "${testdir1}"
+                        mkdir -p "${testdir2}"
+                        mkdir -p "${testdir3}"
+                        touch "${testdir1}/skipped_tests"
+                        touch "${testdir2}/skipped_tests"
+                        touch "${testdir3}/skipped_tests"
+                        exit 0
+                    fi\n''' + config['script']
     if (config['failure_artifacts']) {
         script += '''\nset +x\necho -n "Test artifacts can be found at: "
                      echo "${JOB_URL%/job/*}/view/change-requests/job/$BRANCH_NAME/$BUILD_ID/artifact/''' +
@@ -117,14 +117,14 @@ void call(Map config = [:]) {
     // https://issues.jenkins-ci.org/browse/JENKINS-39203
     // Once that is fixed all of the below should be pushed up into the
     // Jenkinsfile post { stable/unstable/failure/etc. }
-    String status = "SUCCESS"
+    def status = "SUCCESS"
     if (rc != 0) {
         status = "FAILURE"
     } else if (rc == 0) {
-        boolean test_failure = false
-        boolean test_error = false
+        def test_failure = false
+        def test_error = false
         if (config['junit_files']) {
-            Map filesList = []
+            def filesList = []
             config['junit_files'].split().each {
                 filesList.addAll(findFiles(glob: it))
             }
@@ -150,7 +150,7 @@ void call(Map config = [:]) {
         }
         // If we are testing this library, make sure the result is as expected
         if (test_failure || test_error) {
-            String expected_status
+            def expected_status
             if (test_failure) {
                 expected_status = "UNSTABLE"
             } else if (test_error) {


### PR DESCRIPTION
This reverts portions of commit 5162a9c
that converted defs to types and primitives as that was causing:

org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object '[]' with class 'java.util.ArrayList' to class 'java.util.Map' due to: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: java.util.Map()

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>