### PR TITLE
Only run the 'pre' tag on PRs, not 'pr'.

### DIFF
--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -115,7 +115,7 @@ def call(Map config = [:]) {
 
     if (env.STAGE_NAME.contains('Functional')) {
       if (env.BRANCH_NAME == 'master') {
-          core_tag = 'pr'
+          core_tag = 'pr,pre'
       } else {
           core_tag = 'pre'
       }

--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -114,22 +114,27 @@ def call(Map config = [:]) {
     result['node_count'] = 1
 
     if (env.STAGE_NAME.contains('Functional')) {
+      if (env.BRANCH_NAME == 'master') {
+          core_tag = 'pr'
+      } else {
+          core_tag = 'pre'
+      }
       result['test'] = 'Functional'
       result['node_count'] = 9
-      result['test_tag'] = 'pr,-hw'
+      result['test_tag'] = core_tag + ',-hw'
       result['pragma_suffix'] = ''
       result['ftest_arg'] = ''
       if (env.STAGE_NAME.contains('Hardware')) {
-        result['test_tag'] = 'pr,hw,large'
+        result['test_tag'] = core_tag + ',hw,large'
         result['pragma_suffix'] = '-hw-large'
         result['ftest_arg'] = 'auto:Optane'
         if (env.STAGE_NAME.contains('Small')) {
           result['node_count'] = 3
-          result['test_tag'] = 'pr,hw,small'
+          result['test_tag'] = core_tag + ',hw,small'
           result['pragma_suffix'] = '-hw-small'
         } else if (env.STAGE_NAME.contains('Medium')) {
           result['node_count'] = 5
-          result['test_tag'] = 'pr,hw,medium,ib2'
+          result['test_tag'] = core_tag + ',hw,medium,ib2'
           result['pragma_suffix'] = '-hw-medium'
         }
       }


### PR DESCRIPTION
This probably wants new tags, for example 'pr' for prs and 'landings'
for master but using the pr tag for master here means fewer changes
and potential conflicts when testing this change.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>