### PR TITLE
Only run runnable tests in Features: pragma

### DIFF
--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -141,7 +141,11 @@ def call(Map config = [:]) {
       result['test_tag'] = branch_tag + ',' + cluster_size
 
       for (feature in commitPragma(pragma: "Features").split(' ')) {
-        result['test_tag'] += ' ' + feature + ',' + cluster_size
+        // Add tests from all testing buckets
+        // Duplication with branch_tag is not a problem
+        result['test_tag'] += ' pr,' + feature + ',' + cluster_size
+        result['test_tag'] += ' daily_regression,' + feature + ',' + cluster_size
+        result['test_tag'] += ' full_regression,' + feature + ',' + cluster_size
       }
     }
     if (config['test']) {


### PR DESCRIPTION
Limit the tests added by Features: tags to tests that we normally run
in one of our existing test buckets.

Skip-PR-comments: true

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>