### PR TITLE
Followup to previous patch to remove later override

### DIFF
--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -167,9 +167,6 @@ def call(Map config = [:]) {
     if (config['node_count']) {
       result['node_count'] = config['node_count']
     }
-    if (config['test_tag']) {
-      result['test_tag'] = config['test_tag']
-    }
     if (config['pragma_suffix']) {
       result['pragma_suffix'] = config['pragma_suffix']
     }


### PR DESCRIPTION
In working on the last patch, it was missed that subsequent to the
config['test_tag'] processing and combining with the cluster size
restricting tags, into result['test_tag'], a subsequent override of the
result['test_tag'] with the bare config['test_tag'] was being done.

Remove that.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>