### PR TITLE
CORCI-1046 Change to test new provision nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,7 +177,7 @@ pipeline {
                                    profile: 'daos_ci',
                                    node_count: 1,
                                    snapshot: true,
-                                   inst_rpms: "slurm slurm-example-configs" +
+                                   inst_rpms: "slurm" +
                                               " slurm-slurmctld slurm-slurmd" +
                                               " ipmctl"
                     runTest script: '''NODE=${NODELIST%%,*}

--- a/vars/provisionNodesV1.groovy
+++ b/vars/provisionNodesV1.groovy
@@ -257,7 +257,7 @@ EOF'''
     provision_script += '''\nrm -f /etc/profile.d/openmpi.sh
                              rm -f /tmp/daos_control.log
                              yum -y erase metabench mdtest simul IOR compat-openmpi16
-                             if ! yum -y install CUnit python36-PyYAML                         \
+                             if ! yum -y install --exclude=ompi CUnit python36-PyYAML          \
                                                  python36-nose                                 \
                                                  python36-pip valgrind                         \
                                                  python36-paramiko                             \


### PR DESCRIPTION
Copy the scripts from the daos-stack project as a start so that
the provisionNodes tests are now testing the same as Daos

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>