### PR TITLE
Fix API breakage

### DIFF
--- a/vars/functionalTest.groovy
+++ b/vars/functionalTest.groovy
@@ -87,6 +87,10 @@ def call(Map config = [:]) {
   params['context'] = context
   params['description'] = description
 
-  runTestFunctional params
-
+  if (config.get('test_function', "runTestFunctional") ==
+      "runTestFunctionalV2") {
+    runTestFunctionalV2 params
+  } else {
+    runTestFunctional params
+  }
 }

--- a/vars/functionalTestPost.groovy
+++ b/vars/functionalTestPost.groovy
@@ -9,7 +9,7 @@
    *                               Default 'ci/functional/job_cleanup.sh'.
    *
    * config['artifacts']           Artifacts to archive.
-   *                               Default env.STAGE_NAME + '/**'
+   *                               Default 'Functional/**'
    *
    * config['testResults']         Junit test result files.
    *                               Default env.STAGE_NAME subdirectories
@@ -17,18 +17,13 @@
 
 def call(Map config = [:]) {
 
-  def always_script = config.get('always_script',
-                                 'ci/functional/job_cleanup.sh')
-  def rc = sh label: "Job Cleanup",
-           script: always_script,
-           returnStatus: true
-
-  def artifacts = config.get('artifacts', env.STAGE_NAME + '/**')
-  archiveArtifacts artifacts: artifacts
-
-  def junit_results = config.get('testResults',
-                                 env.STAGE_NAME + '/*/*/results.xml, ' +
-                                 env.STAGE_NAME + '/*/framework_results.xml, ' +
-                                 env.STAGE_NAME + '/*/*/test-results/*/data/*_results.xml')
-  junit testResults: junit_results
+    if (!config['artifacts']) {
+        config['artifacts'] = 'Functional/**'
+    }
+    if (!config['testResults']) {
+        config['testResults'] = 'Functional/*/results.xml, ' +
+                                'Functional/*/framework_results.xml, ' +
+                                'Functional/*/test-results/*/data/*_results.xml'
+    }
+    functionalTestPostV2(config)
 }

--- a/vars/functionalTestPostV2.groovy
+++ b/vars/functionalTestPostV2.groovy
@@ -1,0 +1,35 @@
+// vars/functionalTestPostV2.groovy
+
+  /**
+   * functionalTestPost step method
+   *
+   * @param config Map of parameters passed
+   *
+   * config['always_script']       Script to run after any test.
+   *                               Default 'ci/functional/job_cleanup.sh'.
+   *
+   * config['artifacts']           Artifacts to archive.
+   *                               Default env.STAGE_NAME + '/**'
+   *
+   * config['testResults']         Junit test result files.
+   *                               Default env.STAGE_NAME subdirectories
+   */
+
+def call(Map config = [:]) {
+
+    def always_script = config.get('always_script',
+                                   'ci/functional/job_cleanup.sh')
+    def rc = sh label: "Job Cleanup",
+                script: always_script,
+                returnStatus: true
+
+    def artifacts = config.get('artifacts', env.STAGE_NAME + '/**')
+    archiveArtifacts artifacts: artifacts
+
+    def junit_results = config.get('testResults',
+                                   env.STAGE_NAME + '/*/*/results.xml, ' +
+                                   env.STAGE_NAME + '/*/framework_results.xml, ' +
+                                   env.STAGE_NAME + '/*/*/test-results/*/data/*_results.xml')
+
+    junit testResults: junit_results
+}

--- a/vars/runTestFunctional.groovy
+++ b/vars/runTestFunctional.groovy
@@ -38,37 +38,8 @@ void call(Map config = [:]) {
    *                        Default env.STAGE_NAME.
    */
 
-    if (!fileExists('ci/functional/test_main.sh')) {
-        return runTestFunctionalV1(config)
-    }
+    config['failure_artifacts'] = 'Functional'
 
-    Boolean test_rpms = false
-    if (config['test_rpms'] == "true") {
-        test_rpms = true
-    }
-    config['script'] = 'TEST_TAG="' + config['test_tag'] + '" ' +
-                       'FTEST_ARG="' + config['ftest_arg'] + '" ' +
-                       'PRAGMA_SUFFIX="' + config['pragma_suffix'] + '" ' +
-                       'NODE_COUNT="' + config['node_count'] + '" ' +
-                       'OPERATIONS_EMAIL="' + env.OPERATIONS_EMAIL + '" ' +
-                       'ci/functional/test_main.sh'
-                                     
-    config['junit_files'] = "install/lib/daos/TESTING/ftest/avocado/job-results/job-*/*.xml " +
-                            "install/lib/daos/TESTING/ftest/avocado/job-results/job-*/test-results/*/data/*_results.xml"
-    config['failure_artifacts'] = env.STAGE_NAME
-
-    if (test_rpms && config['stashes']){
-        // we don't need (and might not even have) stashes if testing
-        // from RPMs
-        config.remove('stashes')
-    }
-
-    config.remove('pragma_suffix')
-    config.remove('test_tag')
-    config.remove('ftest_arg')
-    config.remove('node_count')
-    config.remove('test_rpms')
-
-    runTest(config)
+    runTestFunctionalV2(config)
 
 }

--- a/vars/runTestFunctionalV1.groovy
+++ b/vars/runTestFunctionalV1.groovy
@@ -108,7 +108,7 @@ def call(Map config = [:]) {
                                      config['node_count'],
                                      config['ftest_arg'])
     config['junit_files'] = "install/lib/daos/TESTING/ftest/avocado/job-results/job-*/*.xml install/lib/daos/TESTING/ftest/*_results.xml"
-    config['failure_artifacts'] = env.STAGE_NAME
+    config['failure_artifacts'] = 'Functional'
 
     if (test_rpms == 'true' && config['stashes']){
         // we don't need (and might not even have) stashes if testing

--- a/vars/runTestFunctionalV2.groovy
+++ b/vars/runTestFunctionalV2.groovy
@@ -1,0 +1,78 @@
+// vars/runTestFunctionalV2.groovy
+
+/**
+ * runTestFunctionalV2.groovy
+ *
+ * runTestFunctionalV2 pipeline step
+ *
+ */
+
+void call(Map config = [:]) {
+  /**
+   * runTestFunctionalV2 step method
+   *
+   * @param config Map of parameters passed
+   * @return None
+   *
+   * config['stashes'] Stashes from the build to unstash
+   * config['ignore_failure'] Whether a FAILURE result should post a failed step
+   * config['pragma_suffix'] The Test-tag pragma suffix
+   * config['test_tag'] The test tags to run
+   * config['ftest_arg'] An argument to ftest.sh
+   * config['test_rpms'] Testing using RPMs, true/false
+   *
+   * config['context'] Context name for SCM to identify the specific stage to
+   *                   update status for.
+   *                   Default is 'test/' + env.STAGE_NAME.
+   * config['failure_artifacts'] Artifacts to link to when test fails, if any.
+                                 Default is env.STAGE_NAME.
+   *
+   *  Important:
+   *     The SCM status checking for passing may expect a specific name.
+   *
+   *     Matrix stages must override this setting to include matrix axes
+   *     names to ensure a unique name is generated.
+   *
+   *     Or the default name has to be changed in a way that is compatible
+   *     with a future Matrix implementation.
+   *
+   * config['description']  Description to report for SCM status.
+   *                        Default env.STAGE_NAME.
+   */
+
+    if (!fileExists('ci/functional/test_main.sh')) {
+        return runTestFunctionalV1(config)
+    }
+
+    Boolean test_rpms = false
+    if (config['test_rpms'] == "true") {
+        test_rpms = true
+    }
+    config['script'] = 'TEST_TAG="' + config['test_tag'] + '" ' +
+                       'FTEST_ARG="' + config['ftest_arg'] + '" ' +
+                       'PRAGMA_SUFFIX="' + config['pragma_suffix'] + '" ' +
+                       'NODE_COUNT="' + config['node_count'] + '" ' +
+                       'OPERATIONS_EMAIL="' + env.OPERATIONS_EMAIL + '" ' +
+                       'ci/functional/test_main.sh'
+                                     
+    config['junit_files'] = "install/lib/daos/TESTING/ftest/avocado/job-results/job-*/*.xml " +
+                            "install/lib/daos/TESTING/ftest/avocado/job-results/job-*/test-results/*/data/*_results.xml"
+    if (!config['failure_artifacts']) {
+        config['failure_artifacts'] = env.STAGE_NAME
+    }
+
+    if (test_rpms && config['stashes']){
+        // we don't need (and might not even have) stashes if testing
+        // from RPMs
+        config.remove('stashes')
+    }
+
+    config.remove('pragma_suffix')
+    config.remove('test_tag')
+    config.remove('ftest_arg')
+    config.remove('node_count')
+    config.remove('test_rpms')
+
+    runTest(config)
+
+}


### PR DESCRIPTION
"DAOS-6274 test: Restructure DAOS logs #184" broke the pipeline-lib API
without providing any backward compatibliity.

This fixes that breakage.