### PR TITLE
DAOS-6742 build: Add CB0 to CACHEBUST option to allow multi-stage.

### DIFF
--- a/vars/dockerBuildArgs.groovy
+++ b/vars/dockerBuildArgs.groovy
@@ -9,8 +9,9 @@
    *
    * config['add_repos'] Whether to add yum repos to image.
    *
-   * config['cachebust'] Whether to set CB0 and CACHEBUST args.
-   *                     CB0 will be set weekly and should force entire rebuild
+   * config['cachebust'] Whether to set CB_WEEKLY and CACHEBUST args.
+   *                     CB_WEEKLY will be set weekly and should force entire
+   *                     rebuild
    *                     CACHEBUST should be unique and should force updates.
    *                     Defaults to true.
    *
@@ -46,7 +47,7 @@ String call(Map config = [:]) {
     if (cachebust) {
       Calendar current_time = Calendar.getInstance()
       ret_str += " --build-arg CACHEBUST=${currentBuild.startTimeInMillis}"
-      ret_str += " --build-arg CB0=" + current_time.get(Calendar.WEEK_OF_YEAR)
+      ret_str += " --build-arg CB_WEEKLY=" + current_time.get(Calendar.WEEK_OF_YEAR)
     }
 
     if (add_repos) {

--- a/vars/dockerBuildArgs.groovy
+++ b/vars/dockerBuildArgs.groovy
@@ -9,9 +9,13 @@
    *
    * config['add_repos'] Whether to add yum repos to image.
    *
-   * config['cachebust'] Whether to add unique id to refresh cache.
+   * config['cachebust'] Whether to set CB0 and CACHEBUST args.
+   *                     CB0 will be set weekly and should force entire rebuild
+   *                     CACHEBUST should be unique and should force updates.
+   *                     Defaults to true.
    *
    * config['deps_build'] Whether to build the daos dependencies.
+   *
    */
 
 // The docker agent setup and the provisionNodes step need to know the
@@ -21,6 +25,8 @@ int getuid() {
               script: "id -u",
               returnStdout: true).trim()
 }
+
+Calendar current_time = Calendar.getInstance()
 
 String call(Map config = [:]) {
     Boolean cachebust = true
@@ -41,6 +47,7 @@ String call(Map config = [:]) {
               " --build-arg JENKINS_URL=$env.JENKINS_URL"
     if (cachebust) {
       ret_str += " --build-arg CACHEBUST=${currentBuild.startTimeInMillis}"
+      ret_str += " --build-arg CB0=" + current_time.get(Calendar.WEEK_OF_YEAR)
     }
 
     if (add_repos) {

--- a/vars/dockerBuildArgs.groovy
+++ b/vars/dockerBuildArgs.groovy
@@ -26,8 +26,6 @@ int getuid() {
               returnStdout: true).trim()
 }
 
-Calendar current_time = Calendar.getInstance()
-
 String call(Map config = [:]) {
     Boolean cachebust = true
     Boolean add_repos = true
@@ -46,6 +44,7 @@ String call(Map config = [:]) {
               " --build-arg UID=" + getuid() +
               " --build-arg JENKINS_URL=$env.JENKINS_URL"
     if (cachebust) {
+      Calendar current_time = Calendar.getInstance()
       ret_str += " --build-arg CACHEBUST=${currentBuild.startTimeInMillis}"
       ret_str += " --build-arg CB0=" + current_time.get(Calendar.WEEK_OF_YEAR)
     }

--- a/vars/dockerBuildArgs.groovy
+++ b/vars/dockerBuildArgs.groovy
@@ -9,9 +9,8 @@
    *
    * config['add_repos'] Whether to add yum repos to image.
    *
-   * config['cachebust'] Whether to set CB_WEEKLY and CACHEBUST args.
-   *                     CB_WEEKLY will be set weekly and should force entire
-   *                     rebuild
+   * config['cachebust'] Whether to set CB0 and CACHEBUST args.
+   *                     CB0 will be set weekly and should force entire rebuild
    *                     CACHEBUST should be unique and should force updates.
    *                     Defaults to true.
    *
@@ -47,7 +46,7 @@ String call(Map config = [:]) {
     if (cachebust) {
       Calendar current_time = Calendar.getInstance()
       ret_str += " --build-arg CACHEBUST=${currentBuild.startTimeInMillis}"
-      ret_str += " --build-arg CB_WEEKLY=" + current_time.get(Calendar.WEEK_OF_YEAR)
+      ret_str += " --build-arg CB0=" + current_time.get(Calendar.WEEK_OF_YEAR)
     }
 
     if (add_repos) {


### PR DESCRIPTION
This allows periodic rebuild as well as per-build refreshes, the
benefit of which is to keep the refresh time from increasing over
time as the base images age.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
