### PR TITLE
CORCI-1074 build: Allow special CI targets

### DIFF
--- a/vars/dockerBuildArgs.groovy
+++ b/vars/dockerBuildArgs.groovy
@@ -16,7 +16,8 @@
    *
    * config['deps_build'] Whether to build the daos dependencies.
    *
-   * config['repo_type'] Type of repo to add.  Default 'local'
+   * config['repo_type'] Type of repo to add.  Default 'local' for compatibilty
+   *                     with older dockerfiles.
    *
    * Repositories URLs are looked up via Jenkins environment variables.
    * There are two environment variables that are put together to create
@@ -90,11 +91,11 @@ String call(Map config = [:]) {
 
     // The docker agent setup and the provisionNodes step need to know the
     // UID that the build agent is running under.
-    ret_str = " --build-arg NOBUILD=1 " +
-              " --build-arg UID=" + sh(label: 'getuid()',
-                                       script: "id -u",
-                                       returnStdout: true).trim() +
-              " --build-arg JENKINS_URL=$env.JENKINS_URL"
+    String ret_str = " --build-arg NOBUILD=1 " +
+                     " --build-arg UID=" + sh(label: 'getuid()',
+                                              script: "id -u",
+                                              returnStdout: true).trim() +
+                     " --build-arg JENKINS_URL=$env.JENKINS_URL"
     if (cachebust) {
       Calendar current_time = Calendar.getInstance()
       ret_str += " --build-arg CACHEBUST=${currentBuild.startTimeInMillis}"
@@ -114,6 +115,11 @@ String call(Map config = [:]) {
         repo_alias = 'EL_8'
         if (daos_type == 'LOCAL') {
           daos_arg = 'EL8'
+        }
+        // Appstream repo not working in Nexus group repos
+        if (env.DAOS_STACK_EL_8_APPSTREAM) {
+          ret_str += " --build-arg REPO_APPSREAM=" +
+                     env.DAOS_STACK_EL_8_APPSTREAM
         }
       } else if (stage_info['target'] == 'leap15') {
         repo_alias = 'LEAP_15'

--- a/vars/functionalPackages.groovy
+++ b/vars/functionalPackages.groovy
@@ -30,8 +30,8 @@ String call(String distro, Integer client_ver, String next_version) {
         distro.startsWith('el7') || distro.startsWith('centos7') ||
         distro.startsWith('el8') || distro.startsWith('centos8') ||
         distro.startsWith('ubuntu20')) {
+        println("Functional Packages -${daos_pkgs}-")
         return daos_pkgs + ' ' + pkgs
-    } else {
-        error 'functionalPackages not implemented for ' + distro
     }
+    error 'functionalPackages not implemented for ' + distro
 }

--- a/vars/functionalPackages.groovy
+++ b/vars/functionalPackages.groovy
@@ -30,7 +30,6 @@ String call(String distro, Integer client_ver, String next_version) {
         distro.startsWith('el7') || distro.startsWith('centos7') ||
         distro.startsWith('el8') || distro.startsWith('centos8') ||
         distro.startsWith('ubuntu20')) {
-        println("Functional Packages -${daos_pkgs}-")
         return daos_pkgs + ' ' + pkgs
     }
     error 'functionalPackages not implemented for ' + distro

--- a/vars/getDAOSPackages.groovy
+++ b/vars/getDAOSPackages.groovy
@@ -25,6 +25,5 @@ String call(String distro, String next_version) {
         return pkgs + "=" + daosPackagesVersion(distro, next_version)
     }
     String ret_str = pkgs + "-" + daosPackagesVersion(distro, next_version)
-    println("getDAOSPackages - pkgs=-${ret_str}")
     return pkgs + "-" + daosPackagesVersion(distro, next_version)
 }

--- a/vars/getDAOSPackages.groovy
+++ b/vars/getDAOSPackages.groovy
@@ -24,5 +24,7 @@ String call(String distro, String next_version) {
     if (distro.startsWith('ubuntu20')) {
         return pkgs + "=" + daosPackagesVersion(distro, next_version)
     }
+    String ret_str = pkgs + "-" + daosPackagesVersion(distro, next_version)
+    println("getDAOSPackages - pkgs=-${ret_str}")
     return pkgs + "-" + daosPackagesVersion(distro, next_version)
 }

--- a/vars/hwDistroTarget.groovy
+++ b/vars/hwDistroTarget.groovy
@@ -15,8 +15,12 @@ String hw_distro(String size) {
     //'leap15
     //'centos7
     //'centos8
+    String distro = 'centos7'
+    if (params.CI_HARDWARE_DISTRO) {
+        distro = params.CI_HARWARE_DISTRO
+    }
     return cachedCommitPragma('Func-hw-test-' + size + '-distro',
-                              cachedCommitPragma('Func-hw-test-distro', 'centos7'))
+                              cachedCommitPragma('Func-hw-test-distro', distro))
 }
 
 String call() {

--- a/vars/hwDistroTarget.groovy
+++ b/vars/hwDistroTarget.groovy
@@ -17,7 +17,7 @@ String hw_distro(String size) {
     //'centos8
     String distro = 'centos7'
     if (params.CI_HARDWARE_DISTRO) {
-        distro = params.CI_HARWARE_DISTRO
+        distro = params.CI_HARDWARE_DISTRO
     }
     return cachedCommitPragma('Func-hw-test-' + size + '-distro',
                               cachedCommitPragma('Func-hw-test-distro', distro))

--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -64,7 +64,7 @@ def call(Map config = [:]) {
       echo "Could not determine target in ${env.STAGE_NAME}, defaulting to EL7"
     }
   }
-  String new_ci_target = env['CI_' +
+  String new_ci_target = param['CI_' +
                               result['target'].toString().toUpperCase() +
                               '_TARGET']
   if (new_ci_target) {
@@ -72,7 +72,7 @@ def call(Map config = [:]) {
   } else {
     result['ci_target'] = result['target']
   }
-  if (env['CI_' + result['target']])
+  if (param['CI_' + result['target']])
 
   if (result['target'].startsWith('el') ||
       result['target'].startsWith('centos')) {
@@ -211,7 +211,6 @@ def call(Map config = [:]) {
     result['test_tag'] = result['test_tag'].trim()
     // if (stage_name.contains('Functional'))
   } else if (stage_name.contains('Storage')) {
-    println("Nodelist = -${env.NODELIST}-")
     if (env.NODELIST) {
       List node_list = env.NODELIST.split(',')
       result['node_count'] = node_list.size()

--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -72,7 +72,6 @@ def call(Map config = [:]) {
   } else {
     result['ci_target'] = result['target']
   }
-  if (params['CI_' + result['target']])
 
   if (result['target'].startsWith('el') ||
       result['target'].startsWith('centos')) {

--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -76,7 +76,7 @@ def call(Map config = [:]) {
   if (result['ci_target'].startsWith('el') ||
       result['ci_target'].startsWith('centos')) {
     result['java_pkg'] = 'java-1.8.0-openjdk'
-  } else if (result['cI_target'].startsWith('ubuntu')) {
+  } else if (result['ci_target'].startsWith('ubuntu')) {
     result['java_pkg'] = 'openjdk-8-jdk'
   } else if (result['ci_target'].startsWith('leap')) {
     result['java_pkg'] = 'java-1_8_0-openjdk'

--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -64,15 +64,15 @@ def call(Map config = [:]) {
       echo "Could not determine target in ${env.STAGE_NAME}, defaulting to EL7"
     }
   }
-  String new_ci_target = param['CI_' +
-                              result['target'].toString().toUpperCase() +
-                              '_TARGET']
+  String new_ci_target = params['CI_' +
+                                result['target'].toString().toUpperCase() +
+                                '_TARGET']
   if (new_ci_target) {
     result['ci_target'] = new_ci_target
   } else {
     result['ci_target'] = result['target']
   }
-  if (param['CI_' + result['target']])
+  if (params['CI_' + result['target']])
 
   if (result['target'].startsWith('el') ||
       result['target'].startsWith('centos')) {

--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -64,6 +64,15 @@ def call(Map config = [:]) {
       echo "Could not determine target in ${env.STAGE_NAME}, defaulting to EL7"
     }
   }
+  String new_ci_target = env['CI_' +
+                              result['target'].toString().toUpperCase() +
+                              '_TARGET']
+  if (new_ci_target) {
+    result['ci_target'] = new_ci_target
+  } else {
+    result['ci_target'] = result['target']
+  }
+  if (env['CI_' + result['target']])
 
   if (result['target'].startsWith('el') ||
       result['target'].startsWith('centos')) {
@@ -200,7 +209,14 @@ def call(Map config = [:]) {
       result['test_tag'] += atag + ',' + cluster_size + ' '
     }
     result['test_tag'] = result['test_tag'].trim()
-  } // if (stage_name.contains('Functional'))
+    // if (stage_name.contains('Functional'))
+  } else if (stage_name.contains('Storage')) {
+    println("Nodelist = -${env.NODELIST}-")
+    if (env.NODELIST) {
+      List node_list = env.NODELIST.split(',')
+      result['node_count'] = node_list.size()
+    }
+  }
   if (config['test']) {
     result['test'] = config['test']
   }

--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -73,15 +73,15 @@ def call(Map config = [:]) {
     result['ci_target'] = result['target']
   }
 
-  if (result['target'].startsWith('el') ||
-      result['target'].startsWith('centos')) {
+  if (result['ci_target'].startsWith('el') ||
+      result['ci_target'].startsWith('centos')) {
     result['java_pkg'] = 'java-1.8.0-openjdk'
-  } else if (result['target'].startsWith('ubuntu')) {
+  } else if (result['cI_target'].startsWith('ubuntu')) {
     result['java_pkg'] = 'openjdk-8-jdk'
-  } else if (result['target'].startsWith('leap')) {
+  } else if (result['ci_target'].startsWith('leap')) {
     result['java_pkg'] = 'java-1_8_0-openjdk'
   } else {
-    error 'Java package not known for ' + result['target']
+    error 'Java package not known for ' + result['ci_target']
   }
 
   result['compiler'] = 'gcc'

--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -111,7 +111,6 @@ def call(Map config = [:]) {
 
   if (!fileExists('ci/provisioning/log_cleanup.sh') ||
       !fileExists('ci/provisioning/post_provision_config.sh')) {
-      println('Falling back to old provisioning code')
       return provisionNodesV1(config)
   }
 

--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -45,10 +45,11 @@
 */
 def call(Map config = [:]) {
 
-  def nodeString = config['NODELIST']
-  def node_list = config['NODELIST'].split(',')
-  def node_max_cnt = node_list.size()
-  def node_cnt = node_max_cnt
+  String nodeString = config['NODELIST']
+  List node_list = config['NODELIST'].split(',')
+  int node_max_cnt = node_list.size()
+  int node_cnt = node_max_cnt
+  String repo_type = config.get('repo_type', 'stable')
   Map new_config = config
   if (config['node_count']) {
     // Matrix builds pass requested node count as a string
@@ -75,8 +76,8 @@ def call(Map config = [:]) {
       return node_cnt
   }
 
-  def distro_type = 'el7'
-  def distro = config.get('distro', 'el7')
+  String distro_type = 'el7'
+  String distro = config.get('distro', 'el7')
   if (distro.startsWith("centos8") || distro.startsWith("el8")) {
     distro_type = 'el8'
   } else if (distro.startsWith("sles") || distro.startsWith("leap") ||
@@ -90,13 +91,10 @@ def call(Map config = [:]) {
       distro_type = 'ubuntu'
   }
 
-  def inst_rpms = config.get('inst_rpms', '')
-  def inst_repos = config.get('inst_repos','')
+  String inst_rpms = config.get('inst_rpms', '')
+  String inst_repos = config.get('inst_repos','')
 
-  def repository_g = ''
-  def repository_l = ''
-
-  def gpg_key_urls = []
+  List gpg_key_urls = []
   if (env.DAOS_STACK_REPO_SUPPORT != null) {
      gpg_key_urls.add(env.DAOS_STACK_REPO_SUPPORT + 'RPM-GPG-KEY-CentOS-7')
      gpg_key_urls.add(env.DAOS_STACK_REPO_SUPPORT +
@@ -110,45 +108,10 @@ def call(Map config = [:]) {
                         env.DAOS_STACK_REPO_PUB_KEY)
      }
   }
-  if (env.REPOSITORY_URL != null) {
-    if (distro_type == 'el7') {
-        if (env.DAOS_STACK_EL_7_GROUP_REPO != null) {
-            repository_g = env.REPOSITORY_URL + env.DAOS_STACK_EL_7_GROUP_REPO
-        }
-        if (env.DAOS_STACK_EL_7_LOCAL_REPO != null) {
-            repository_l = env.REPOSITORY_URL + env.DAOS_STACK_EL_7_LOCAL_REPO
-        }
-    } else if (distro_type == 'el8') {
-        if (env.DAOS_STACK_EL_8_GROUP_REPO != null) {
-            repository_g = env.REPOSITORY_URL + env.DAOS_STACK_EL_8_GROUP_REPO
-        }
-        if (env.DAOS_STACK_EL_8_LOCAL_REPO != null) {
-            repository_l = env.REPOSITORY_URL + env.DAOS_STACK_EL_8_LOCAL_REPO
-        }
-    } else if (distro.startsWith("sles15")) {
-        if (env.DAOS_STACK_SLES_15_GROUP_REPO != null) {
-            repository_g = env.REPOSITORY_URL +
-                env.DAOS_STACK_SLES_15_GROUP_REPO
-        }
-        if (env.DAOS_STACK_SLES_15_LOCAL_REPO != null) {
-            repository_l = env.REPOSITORY_URL +
-                env.DAOS_STACK_SLES_15_LOCAL_REPO
-        }
-    }  else if (distro.startsWith("leap15") ||
-                distro.startsWith("opensuse15")) {
-        if (env.DAOS_STACK_LEAP_15_GROUP_REPO != null) {
-            repository_g = env.REPOSITORY_URL +
-                env.DAOS_STACK_LEAP_15_GROUP_REPO
-        }
-        if (env.DAOS_STACK_LEAP_15_LOCAL_REPO != null) {
-            repository_l = env.REPOSITORY_URL +
-                env.DAOS_STACK_LEAP_15_LOCAL_REPO
-        }
-    }
-  }
 
   if (!fileExists('ci/provisioning/log_cleanup.sh') ||
       !fileExists('ci/provisioning/post_provision_config.sh')) {
+      println('Falling back to old provisioning code')
       return provisionNodesV1(config)
   }
 
@@ -180,7 +143,6 @@ def call(Map config = [:]) {
                       'GPG_KEY_URLS="' + gpg_key_urls.join(' ') + '" ' +
                       'ci/provisioning/post_provision_config.sh'
   new_config['post_restore'] = provision_script
-
   try {
     def rc = provisionNodesSystem(new_config)
     if (rc != 0) {

--- a/vars/rpmTestVersion.groovy
+++ b/vars/rpmTestVersion.groovy
@@ -11,5 +11,8 @@
  */
 
 boolean call() {
+    if (env.CI_NOBUILD == "true") {
+        return env.CI_RPM_TEST_VERSION
+    }
     return cachedCommitPragma('RPM-test-version')
 }

--- a/vars/scanRpms.groovy
+++ b/vars/scanRpms.groovy
@@ -53,21 +53,21 @@ def call(Map config = [:]) {
     error 'daos_pkg_version is required.'
   }
 
-  def nodelist = config.get('NODELIST', env.NODELIST)
-  def context = config.get('context', 'test/' + env.STAGE_NAME)
-  def description = config.get('description', env.STAGE_NAME)
-  def test_script = config.get('test_script', 'ci/rpm_scan_daos_test.sh')
-  def inst_rpms = config.get('inst_rpms', 'clamav clamav-devel')
+  String nodelist = config.get('NODELIST', env.NODELIST)
+  String context = config.get('context', 'test/' + env.STAGE_NAME)
+  String description = config.get('description', env.STAGE_NAME)
+  String test_script = config.get('test_script', 'ci/rpm_scan_daos_test.sh')
+  String inst_rpms = config.get('inst_rpms', 'clamav clamav-devel')
 
   Map stage_info = parseStageInfo(config)
 
   provisionNodes NODELIST: nodelist,
                  node_count: 1,
-                 distro: stage_info['target'],
-                 inst_repos: config['inst_repos']
+                 distro: stage_info['ci_target'],
+                 inst_repos: config.get('inst_repos', ''),
                  inst_rpmms: inst_rpms
 
-  def full_test_script = 'export DAOS_PKG_VERSION=' +
+  String full_test_script = 'export DAOS_PKG_VERSION=' +
                          config['daos_pkg_version'] + '\n' +
                          test_script
 

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -15,7 +15,7 @@ String skip_stage_pragma(String stage, String def_val='false') {
 }
 
 boolean skip_ftest(String distro) {
-    return env['CI_FUNCTIONAL_' + distro + '_TEST'] == 'false' ||
+    return param['CI_FUNCTIONAL_' + distro + '_TEST'] == 'false' ||
            distro == 'ubuntu20' ||
            skip_stage_pragma('func-test') ||
            skip_stage_pragma('func-test-vm') ||
@@ -25,7 +25,7 @@ boolean skip_ftest(String distro) {
 
 boolean skip_ftest_hw(String size) {
     return env.DAOS_STACK_CI_HARDWARE_SKIP == 'true' ||
-           env['CI_' + size + '_TEST'] == 'false' ||
+           param['CI_' + size + '_TEST'] == 'false' ||
            skip_stage_pragma('func-test') ||
            skip_stage_pragma('func-hw-test-' + size) ||
            ! testsInStage() ||
@@ -34,7 +34,7 @@ boolean skip_ftest_hw(String size) {
 }
 
 boolean skip_if_unstable() {
-    if (env.CI_ALLOW_UNSTABLE_TEST == 'true' ||
+    if (param.CI_ALLOW_UNSTABLE_TEST == 'true' ||
         cachedCommitPragma('Allow-unstable-test').toLowerCase() == 'true' ||
         env.BRANCH_NAME == 'master' ||
         env.BRANCH_NAME.startsWith("weekly-testing") ||
@@ -84,7 +84,7 @@ boolean call(Map config = [:]) {
         case "Build":
             // always build branch landings as we depend on lastSuccessfulBuild
             // always having RPMs in it
-            return env.CI_NOBUILD == 'true' ||
+            return param.CI_NOBUILD == 'true' ||
                    (env.BRANCH_NAME != target_branch) &&
                    skip_stage_pragma('build') ||
                    docOnlyChange(target_branch) ||
@@ -129,7 +129,7 @@ boolean call(Map config = [:]) {
                    quickBuild()
         case "Unit Tests":
             return  env.NO_CI_TESTING == 'true' ||
-                    env.CI_NOBUILD == 'true' ||
+                    param.CI_NOBUILD == 'true' ||
                     skip_stage_pragma('build')
                     docOnlyChange(target_branch) ||
                     skip_build_on_centos7_gcc() ||
@@ -139,10 +139,10 @@ boolean call(Map config = [:]) {
         case "Unit Test Bullseye":
             return skip_stage_pragma('bullseye', 'true')
         case "Unit Test with memcheck":
-            return env.CI_UNIT_TEST_MEMCHECK == 'false' ||
+            return param.CI_UNIT_TEST_MEMCHECK == 'false' ||
                    skip_stage_pragma('unit-test-memcheck')
         case "Unit Test":
-            return env.CI_UNIT_TEST == 'false' ||
+            return param.CI_UNIT_TEST == 'false' ||
                    skip_stage_pragma('unit-test') ||
                    skip_stage_pragma('run_test')
         case "Test":
@@ -171,7 +171,7 @@ boolean call(Map config = [:]) {
             return skip_stage_pragma('vagrant-test', 'true') &&
                    ! env.BRANCH_NAME.startsWith('weekly-testing')
         case "Coverity on CentOS 7":
-            return env.CI_NOBUILD == 'true' ||
+            return param.CI_NOBUILD == 'true' ||
                    skip_stage_pragma('coverity-test') ||
                    quickFunctional() ||
                    skip_stage_pragma('build')
@@ -184,13 +184,13 @@ boolean call(Map config = [:]) {
         case "Functional on Ubuntu 20.04":
             return skip_ftest('ubuntu20') 
         case "Test CentOS 7 RPMs":
-            return env.CI_RPMS_el7_TEST == 'false' ||
+            return param.CI_RPMS_el7_TEST == 'false' ||
                    target_branch == 'weekly-testing' ||
                    skip_stage_pragma('test') ||
                    skip_stage_pragma('test-centos-rpms') ||
                    quickFunctional()
         case "Scan CentOS 7 RPMs":
-            return env.CI_SCAN_RPMS_el7_TEST == 'false' ||
+            return param.CI_SCAN_RPMS_el7_TEST == 'false' ||
                    target_branch == 'weekly-testing' ||
                    skip_stage_pragma('scan-centos-rpms') ||
                    quickFunctional()

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -15,7 +15,8 @@ String skip_stage_pragma(String stage, String def_val='false') {
 }
 
 boolean skip_ftest(String distro) {
-    return distro == 'ubuntu20' ||
+    return env['CI_FUNCTIONAL_' + distro + '_TEST'] == 'false' ||
+           distro == 'ubuntu20' ||
            skip_stage_pragma('func-test') ||
            skip_stage_pragma('func-test-vm') ||
            ! testsInStage() ||
@@ -24,6 +25,7 @@ boolean skip_ftest(String distro) {
 
 boolean skip_ftest_hw(String size) {
     return env.DAOS_STACK_CI_HARDWARE_SKIP == 'true' ||
+           env['CI_' + size + '_TEST'] == 'false' ||
            skip_stage_pragma('func-test') ||
            skip_stage_pragma('func-hw-test-' + size) ||
            ! testsInStage() ||
@@ -32,7 +34,8 @@ boolean skip_ftest_hw(String size) {
 }
 
 boolean skip_if_unstable() {
-    if (cachedCommitPragma('Allow-unstable-test').toLowerCase() == 'true' ||
+    if (env.CI_ALLOW_UNSTABLE_TEST == 'true' ||
+        cachedCommitPragma('Allow-unstable-test').toLowerCase() == 'true' ||
         env.BRANCH_NAME == 'master' ||
         env.BRANCH_NAME.startsWith("weekly-testing") ||
         env.BRANCH_NAME.startsWith("release/")) {
@@ -81,7 +84,8 @@ boolean call(Map config = [:]) {
         case "Build":
             // always build branch landings as we depend on lastSuccessfulBuild
             // always having RPMs in it
-            return (env.BRANCH_NAME != target_branch) &&
+            return env.CI_NOBUILD == 'true' ||
+                   (env.BRANCH_NAME != target_branch) &&
                    skip_stage_pragma('build') ||
                    docOnlyChange(target_branch) ||
                    rpmTestVersion() != ''
@@ -125,8 +129,8 @@ boolean call(Map config = [:]) {
                    quickBuild()
         case "Unit Tests":
             return  env.NO_CI_TESTING == 'true' ||
-                    (skip_stage_pragma('build') &&
-                     rpmTestVersion() == '') ||
+                    env.CI_NOBUILD == 'true' ||
+                    skip_stage_pragma('build')
                     docOnlyChange(target_branch) ||
                     skip_build_on_centos7_gcc() ||
                     skip_stage_pragma('unit-tests')
@@ -135,9 +139,11 @@ boolean call(Map config = [:]) {
         case "Unit Test Bullseye":
             return skip_stage_pragma('bullseye', 'true')
         case "Unit Test with memcheck":
-            return skip_stage_pragma('unit-test-memcheck')
+            return env.CI_UNIT_TEST_MEMCHECK == 'false' ||
+                   skip_stage_pragma('unit-test-memcheck')
         case "Unit Test":
-            return skip_stage_pragma('unit-test') ||
+            return env.CI_UNIT_TEST == 'false' ||
+                   skip_stage_pragma('unit-test') ||
                    skip_stage_pragma('run_test')
         case "Test":
             return env.NO_CI_TESTING == 'true' ||
@@ -165,7 +171,8 @@ boolean call(Map config = [:]) {
             return skip_stage_pragma('vagrant-test', 'true') &&
                    ! env.BRANCH_NAME.startsWith('weekly-testing')
         case "Coverity on CentOS 7":
-            return skip_stage_pragma('coverity-test') ||
+            return env.CI_NOBUILD == 'true' ||
+                   skip_stage_pragma('coverity-test') ||
                    quickFunctional() ||
                    skip_stage_pragma('build')
         case "Functional on CentOS 7":
@@ -177,13 +184,15 @@ boolean call(Map config = [:]) {
         case "Functional on Ubuntu 20.04":
             return skip_ftest('ubuntu20') 
         case "Test CentOS 7 RPMs":
-            return target_branch == 'weekly-testing' ||
+            return env.CI_RPMS_el7_TEST == 'false' ||
+                   target_branch == 'weekly-testing' ||
                    skip_stage_pragma('test') ||
                    skip_stage_pragma('test-centos-rpms') ||
                    quickFunctional()
         case "Scan CentOS 7 RPMs":
-            return target_branch == 'weekly-testing' ||
-                   skip_stage_pragma('scan-centos-rpms', 'true') ||
+            return env.CI_SCAN_RPMS_el7_TEST == 'false' ||
+                   target_branch == 'weekly-testing' ||
+                   skip_stage_pragma('scan-centos-rpms') ||
                    quickFunctional()
         case "Functional_Hardware_Small":
         case "Functional Hardware Small":

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -15,7 +15,7 @@ String skip_stage_pragma(String stage, String def_val='false') {
 }
 
 boolean skip_ftest(String distro) {
-    return params['CI_FUNCTIONAL_' + distro + '_TEST'] == 'false' ||
+    return !params['CI_FUNCTIONAL_' + distro + '_TEST'] ||
            distro == 'ubuntu20' ||
            skip_stage_pragma('func-test') ||
            skip_stage_pragma('func-test-vm') ||
@@ -25,7 +25,7 @@ boolean skip_ftest(String distro) {
 
 boolean skip_ftest_hw(String size) {
     return env.DAOS_STACK_CI_HARDWARE_SKIP == 'true' ||
-           params['CI_' + size + '_TEST'] == 'false' ||
+           ! params['CI_' + size + '_TEST'] ||
            skip_stage_pragma('func-test') ||
            skip_stage_pragma('func-hw-test-' + size) ||
            ! testsInStage() ||
@@ -34,7 +34,7 @@ boolean skip_ftest_hw(String size) {
 }
 
 boolean skip_if_unstable() {
-    if (params.CI_ALLOW_UNSTABLE_TEST == 'true' ||
+    if (params.CI_ALLOW_UNSTABLE_TEST ||
         cachedCommitPragma('Allow-unstable-test').toLowerCase() == 'true' ||
         env.BRANCH_NAME == 'master' ||
         env.BRANCH_NAME.startsWith("weekly-testing") ||
@@ -84,7 +84,7 @@ boolean call(Map config = [:]) {
         case "Build":
             // always build branch landings as we depend on lastSuccessfulBuild
             // always having RPMs in it
-            return params.CI_NOBUILD == 'true' ||
+            return params.CI_NOBUILD ||
                    (env.BRANCH_NAME != target_branch) &&
                    skip_stage_pragma('build') ||
                    docOnlyChange(target_branch) ||
@@ -129,7 +129,7 @@ boolean call(Map config = [:]) {
                    quickBuild()
         case "Unit Tests":
             return  env.NO_CI_TESTING == 'true' ||
-                    params.CI_NOBUILD == 'true' ||
+                    params.CI_NOBUILD ||
                     skip_stage_pragma('build')
                     docOnlyChange(target_branch) ||
                     skip_build_on_centos7_gcc() ||
@@ -139,10 +139,10 @@ boolean call(Map config = [:]) {
         case "Unit Test Bullseye":
             return skip_stage_pragma('bullseye', 'true')
         case "Unit Test with memcheck":
-            return params.CI_UNIT_TEST_MEMCHECK == 'false' ||
+            return ! params.CI_UNIT_TEST_MEMCHECK ||
                    skip_stage_pragma('unit-test-memcheck')
         case "Unit Test":
-            return params.CI_UNIT_TEST == 'false' ||
+            return params.CI_UNIT_TEST ||
                    skip_stage_pragma('unit-test') ||
                    skip_stage_pragma('run_test')
         case "Test":
@@ -171,7 +171,7 @@ boolean call(Map config = [:]) {
             return skip_stage_pragma('vagrant-test', 'true') &&
                    ! env.BRANCH_NAME.startsWith('weekly-testing')
         case "Coverity on CentOS 7":
-            return params.CI_NOBUILD == 'true' ||
+            return params.CI_NOBUILD ||
                    skip_stage_pragma('coverity-test') ||
                    quickFunctional() ||
                    skip_stage_pragma('build')
@@ -184,13 +184,13 @@ boolean call(Map config = [:]) {
         case "Functional on Ubuntu 20.04":
             return skip_ftest('ubuntu20') 
         case "Test CentOS 7 RPMs":
-            return params.CI_RPMS_el7_TEST == 'false' ||
+            return ! params.CI_RPMS_el7_TEST ||
                    target_branch == 'weekly-testing' ||
                    skip_stage_pragma('test') ||
                    skip_stage_pragma('test-centos-rpms') ||
                    quickFunctional()
         case "Scan CentOS 7 RPMs":
-            return params.CI_SCAN_RPMS_el7_TEST == 'false' ||
+            return ! params.CI_SCAN_RPMS_el7_TEST ||
                    target_branch == 'weekly-testing' ||
                    skip_stage_pragma('scan-centos-rpms') ||
                    quickFunctional()

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -15,7 +15,7 @@ String skip_stage_pragma(String stage, String def_val='false') {
 }
 
 boolean skip_ftest(String distro) {
-    return param['CI_FUNCTIONAL_' + distro + '_TEST'] == 'false' ||
+    return params['CI_FUNCTIONAL_' + distro + '_TEST'] == 'false' ||
            distro == 'ubuntu20' ||
            skip_stage_pragma('func-test') ||
            skip_stage_pragma('func-test-vm') ||
@@ -25,7 +25,7 @@ boolean skip_ftest(String distro) {
 
 boolean skip_ftest_hw(String size) {
     return env.DAOS_STACK_CI_HARDWARE_SKIP == 'true' ||
-           param['CI_' + size + '_TEST'] == 'false' ||
+           params['CI_' + size + '_TEST'] == 'false' ||
            skip_stage_pragma('func-test') ||
            skip_stage_pragma('func-hw-test-' + size) ||
            ! testsInStage() ||
@@ -34,7 +34,7 @@ boolean skip_ftest_hw(String size) {
 }
 
 boolean skip_if_unstable() {
-    if (param.CI_ALLOW_UNSTABLE_TEST == 'true' ||
+    if (params.CI_ALLOW_UNSTABLE_TEST == 'true' ||
         cachedCommitPragma('Allow-unstable-test').toLowerCase() == 'true' ||
         env.BRANCH_NAME == 'master' ||
         env.BRANCH_NAME.startsWith("weekly-testing") ||
@@ -84,7 +84,7 @@ boolean call(Map config = [:]) {
         case "Build":
             // always build branch landings as we depend on lastSuccessfulBuild
             // always having RPMs in it
-            return param.CI_NOBUILD == 'true' ||
+            return params.CI_NOBUILD == 'true' ||
                    (env.BRANCH_NAME != target_branch) &&
                    skip_stage_pragma('build') ||
                    docOnlyChange(target_branch) ||
@@ -129,7 +129,7 @@ boolean call(Map config = [:]) {
                    quickBuild()
         case "Unit Tests":
             return  env.NO_CI_TESTING == 'true' ||
-                    param.CI_NOBUILD == 'true' ||
+                    params.CI_NOBUILD == 'true' ||
                     skip_stage_pragma('build')
                     docOnlyChange(target_branch) ||
                     skip_build_on_centos7_gcc() ||
@@ -139,10 +139,10 @@ boolean call(Map config = [:]) {
         case "Unit Test Bullseye":
             return skip_stage_pragma('bullseye', 'true')
         case "Unit Test with memcheck":
-            return param.CI_UNIT_TEST_MEMCHECK == 'false' ||
+            return params.CI_UNIT_TEST_MEMCHECK == 'false' ||
                    skip_stage_pragma('unit-test-memcheck')
         case "Unit Test":
-            return param.CI_UNIT_TEST == 'false' ||
+            return params.CI_UNIT_TEST == 'false' ||
                    skip_stage_pragma('unit-test') ||
                    skip_stage_pragma('run_test')
         case "Test":
@@ -171,7 +171,7 @@ boolean call(Map config = [:]) {
             return skip_stage_pragma('vagrant-test', 'true') &&
                    ! env.BRANCH_NAME.startsWith('weekly-testing')
         case "Coverity on CentOS 7":
-            return param.CI_NOBUILD == 'true' ||
+            return params.CI_NOBUILD == 'true' ||
                    skip_stage_pragma('coverity-test') ||
                    quickFunctional() ||
                    skip_stage_pragma('build')
@@ -184,13 +184,13 @@ boolean call(Map config = [:]) {
         case "Functional on Ubuntu 20.04":
             return skip_ftest('ubuntu20') 
         case "Test CentOS 7 RPMs":
-            return param.CI_RPMS_el7_TEST == 'false' ||
+            return params.CI_RPMS_el7_TEST == 'false' ||
                    target_branch == 'weekly-testing' ||
                    skip_stage_pragma('test') ||
                    skip_stage_pragma('test-centos-rpms') ||
                    quickFunctional()
         case "Scan CentOS 7 RPMs":
-            return param.CI_SCAN_RPMS_el7_TEST == 'false' ||
+            return params.CI_SCAN_RPMS_el7_TEST == 'false' ||
                    target_branch == 'weekly-testing' ||
                    skip_stage_pragma('scan-centos-rpms') ||
                    quickFunctional()

--- a/vars/storagePrepTest.groovy
+++ b/vars/storagePrepTest.groovy
@@ -56,39 +56,19 @@
 
 def call(Map config = [:]) {
 
-  println("Entering Storage Prep Test")
-  def nodelist = config.get('NODELIST', env.NODELIST)
-  def context = config.get('context', 'test/' + env.STAGE_NAME)
-  def description = config.get('description', env.STAGE_NAME)
+  String nodelist = config.get('NODELIST', env.NODELIST)
+  String context = config.get('context', 'test/' + env.STAGE_NAME)
+  String description = config.get('description', env.STAGE_NAME)
  
-  println("Calling parseStage_info")
   Map stage_info = parseStageInfo(config)
 
-  println("config = -${config}-")
-
-  println("Calling ProvisionNodes")
   provisionNodes NODELIST: nodelist,
                  node_count: stage_info['node_count'],
                  distro: stage_info['ci_target'],
                  inst_repos: config.get('inst_repos', ''),
                  inst_rpms: config.get('inst_rpms', '')
 
-  def stashes = []
-  if (config['stashes']) {
-    stashes = config['stashes']
-  } else {
-    def target_compiler = "${stage_info['target']}-${stage_info['compiler']}"
-    stashes.add("${target_compiler}-install")
-    stashes.add("${target_compiler}-build-vars")
-  }
-
   Map params = [:]
-  params['stashes'] = stashes
-  params['test_rpms'] = config.get('test_rpms', env.TEST_RPMS)
-  params['pragma_suffix'] = stage_info['pragma_suffix']
-  params['test_tag'] =  config.get('test_tag', stage_info['test_tag'])
-  params['node_count'] = stage_info['node_count']
-  params['ftest_arg'] = stage_info['ftest_arg']
   params['context'] = context
   params['description'] = description
 
@@ -112,18 +92,6 @@ def call(Map config = [:]) {
   if (!config['failure_artifacts']) {
     config['failure_artifacts'] = env.STAGE_NAME
   }
-
-  if (test_rpms && config['stashes']) {
-    // we don't need (and might not even have) stashes if testing
-    // from RPMs
-    config.remove('stashes')
-  }
-
-  config.remove('pragma_suffix')
-  config.remove('test_tag')
-  config.remove('ftest_arg')
-  config.remove('node_count')
-  config.remove('test_rpms')
 
   runTest(config)
 }

--- a/vars/testRpm.groovy
+++ b/vars/testRpm.groovy
@@ -53,21 +53,21 @@ def call(Map config = [:]) {
     error 'daos_pkg_version is required.'
   }
 
-  def nodelist = config.get('NODELIST', env.NODELIST)
-  def context = config.get('context', 'test/' + env.STAGE_NAME)
-  def description = config.get('description', env.STAGE_NAME)
-  def test_script = config.get('test_script', 'ci/rpm/test_daos.sh')
+  String nodelist = config.get('NODELIST', env.NODELIST)
+  String context = config.get('context', 'test/' + env.STAGE_NAME)
+  String description = config.get('description', env.STAGE_NAME)
+  String test_script = config.get('test_script', 'ci/rpm/test_daos.sh')
 
   Map stage_info = parseStageInfo(config)
 
   provisionNodes NODELIST: nodelist,
                  node_count: 1,
                  profile: config.get('profile', 'daos_ci'),
-                 distro: stage_info['target'],
+                 distro: stage_info['ci_target'],
                  inst_repos: config.get('inst_repos', ''),
                  inst_rpms: config.get('inst_rpms', '')
 
-  def full_test_script = 'export DAOS_PKG_VERSION=' +
+  String full_test_script = 'export DAOS_PKG_VERSION=' +
                          config['daos_pkg_version'] + '\n' +
                          test_script
 

--- a/vars/unitTest.groovy
+++ b/vars/unitTest.groovy
@@ -69,8 +69,8 @@
 
 def call(Map config = [:]) {
 
-  def nodelist = config.get('NODELIST', env.NODELIST)
-  def test_script = config.get('test_script', 'ci/unit/test_main.sh')
+  String nodelist = config.get('NODELIST', env.NODELIST)
+  String test_script = config.get('test_script', 'ci/unit/test_main.sh')
 
   Map stage_info = parseStageInfo(config)
 
@@ -84,16 +84,16 @@ def call(Map config = [:]) {
 
   provisionNodes NODELIST: nodelist,
                  node_count: stage_info['node_count'],
-                 distro: stage_info['target'],
-                 inst_repos: config['inst_repos'],
+                 distro: stage_info['ci_target'],
+                 inst_repos: config.get('inst_repos', ''),
                  inst_rpms: inst_rpms
 
-  def target_stash = "${stage_info['target']}-${stage_info['compiler']}"
+  String target_stash = "${stage_info['target']}-${stage_info['compiler']}"
   if (stage_info['build_type']) {
     target_stash += '-' + stage_info['build_type']
   }
 
-  def stashes = []
+  List stashes = []
   if (config['stashes']) {
     stashes = config['stashes']
   } else {
@@ -104,7 +104,7 @@ def call(Map config = [:]) {
 
   if (stage_info['compiler'] == 'covc') {
 
-    def tools_url = env.JENKINS_URL +
+    String tools_url = env.JENKINS_URL +
                     'job/daos-stack/job/tools/job/master' +
                     '/lastSuccessfulBuild/artifact/'
     httpRequest url: tools_url + 'bullseyecoverage-linux.tar',
@@ -123,8 +123,8 @@ def call(Map config = [:]) {
   params['description'] = config.get('description', env.STAGE_NAME)
   params['ignore_failure'] = config.get('ignore_failure', false)
 
-  def time = config.get('timeout_time', 120) as int
-  def unit = config.get('timeout_unit', 'MINUTES')
+  int time = config.get('timeout_time', 120) as int
+  String unit = config.get('timeout_unit', 'MINUTES')
 
   timeout(time: time, unit: unit) {
     runTest params


### PR DESCRIPTION
Separate out a 'ci_target' from a build 'target' to allow more easily
running tests on newer pre-built CI images.

dockerBuildArgs.groovy:
   Add CentOS 8 special app stream repo
   Fix missing variable declaration

parseStageInfo.groovy
   Set the 'ci_target' member for node provisioning

functionalTest.groovy:
scanRpms.groovy:
testRpm.groovy:
unitTest.groovy
   Now use 'ci_target' for node provisioning

provisionNodes.groovy:
   Fix some declarations to be more specific types
   Remove some dead code

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>