### PR TITLE
DAOS-623 build: Change priority of landings on master back to default.

### DIFF
--- a/vars/getPriority.groovy
+++ b/vars/getPriority.groovy
@@ -8,7 +8,7 @@
    */
 
 def call() {
-      if (env.BRANCH_NAME == 'master' ||
+      if (startedByTimer() ||
         env.BRANCH_NAME.startsWith("release/") ||
         env.BRANCH_NAME == 'weekly-testing') {
         string p = '2'


### PR DESCRIPTION
This will prevent landings on master consuming test cycles
ahead of development.wq

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
