### PR TITLE
CORCI-1081 ci: Changes to increase CI throughput

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@
 // That PR should be landed with out deleting the PR branch.
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
-@Library(value="pipeline-lib@bmurrell/shuffle-builds") _
+//@Library(value="pipeline-lib@my_branch_name") _
 
 pipeline {
     agent { label 'lightweight' }

--- a/vars/cachedCommitPragma.groovy
+++ b/vars/cachedCommitPragma.groovy
@@ -15,6 +15,13 @@ import groovy.transform.Field
 @Field static commit_pragma_cache = [:]
 
 def call(Map config = [:]) {
+    if (config['clear']) {
+        commit_pragma_cache.clear()
+        return
+    } else if (config['dump']) {
+        return commit_pragma_cache
+    }
+
     // convert the map for compat
     return cachedCommitPragma(config['pragma'], config['def_val'])
 }

--- a/vars/getPriority.groovy
+++ b/vars/getPriority.groovy
@@ -8,9 +8,7 @@
    */
 
 def call() {
-      if (env.BRANCH_NAME == 'master' ||
-        env.BRANCH_NAME.startsWith("release/") ||
-        env.BRANCH_NAME == 'weekly-testing') {
+      if (env.BRANCH_NAME == 'weekly-testing') {
         string p = '2'
     } else {
         string p = ''

--- a/vars/testsInStage.groovy
+++ b/vars/testsInStage.groovy
@@ -21,7 +21,10 @@ boolean call() {
     }
 
     return sh(label: "Get test list",
-              script: """cd src/tests/ftest
+              script: """if [ \${UNIT_TEST:-false} ]; then
+                             exit 0
+                         fi
+                         cd src/tests/ftest
                          ./list_tests.py """ + parseStageInfo()['test_tag'],
               returnStatus: true) == 0
 }


### PR DESCRIPTION
Change PRs to only run CentOS7 on VMs.

Landings and timed builds are moved down to the same priority as PRs.

Run build and test stages on an empty commit message with PR-repos* set.
Because there are no code changes, these commits will pass the doc-only
test and not run build and test, but the PR-repos* pragmas tell us that
this is a commit being used to test updates to a dependency build.

Skip UT stage on Quick-build (which is implied with Quick-Functional).