### PR TITLE
CORCI-1074 build: Allow special CI targets

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value="pipeline-lib@my_branch_name") _
+@Library(value="pipeline-lib@corci-1047b") _
 
 pipeline {
     agent { label 'lightweight' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value="pipeline-lib@my_branch_name") _
-@Library(value="pipeline-lib@corci-1047b") _
+@Library(value="pipeline-lib@corci-1074b") _
 
 pipeline {
     agent { label 'lightweight' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,6 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value="pipeline-lib@my_branch_name") _
-@Library(value="pipeline-lib@corci-1074b") _
 
 pipeline {
     agent { label 'lightweight' }

--- a/vars/daosPackagesVersion.groovy
+++ b/vars/daosPackagesVersion.groovy
@@ -29,7 +29,7 @@ String daos_latest_version(String next_version, String repo_type='stable') {
 String rpm_dist(String distro) {
     if (distro.startsWith('el7') || distro.startsWith('centos7')) {
         return ".el7"
-    if (distro.startsWith('el8') || distro.startsWith('centos8')) {
+    } else if (distro.startsWith('el8') || distro.startsWith('centos8')) {
         return ".el8"
     } else if (distro.startsWith("leap15")) {
         return ".suse.lp152"

--- a/vars/daosPackagesVersion.groovy
+++ b/vars/daosPackagesVersion.groovy
@@ -29,6 +29,8 @@ String daos_latest_version(String next_version, String repo_type='stable') {
 String rpm_dist(String distro) {
     if (distro.startsWith('el7') || distro.startsWith('centos7')) {
         return ".el7"
+    if (distro.startsWith('el8') || distro.startsWith('centos8')) {
+        return ".el8"
     } else if (distro.startsWith("leap15")) {
         return ".suse.lp152"
     } else {

--- a/vars/daosPackagesVersion.groovy
+++ b/vars/daosPackagesVersion.groovy
@@ -18,7 +18,7 @@ String daos_latest_version(String next_version, String repo_type='stable') {
     String v = sh(label: "Get RPM packages version",
                   script: 'repoquery --repofrompath=daos,' + env.REPOSITORY_URL +
                           env["DAOS_STACK_EL_7_" + repo_type.toUpperCase() + "_REPO"] +
-                        '''/ --repoid daos --qf %{version}-%{release} --whatprovides 'daos(x86-64) < ''' +
+                        '''/ --repoid daos --qf %{version}-%{release} --whatprovides 'daos-tests(x86-64) < ''' +
                                      next_version + '''' |
                                  rpmdev-sort | tail -1''',
                   returnStdout: true).trim()

--- a/vars/functionalPackages.groovy
+++ b/vars/functionalPackages.groovy
@@ -31,7 +31,6 @@ String call(String distro, Integer client_ver, String next_version) {
         distro.startsWith('el8') || distro.startsWith('centos8') ||
         distro.startsWith('ubuntu20')) {
         return daos_pkgs + ' ' + pkgs
-    } else {
-        error 'functionalPackages not implemented for ' + distro
     }
+    error 'functionalPackages not implemented for ' + distro
 }

--- a/vars/functionalTest.groovy
+++ b/vars/functionalTest.groovy
@@ -56,19 +56,19 @@
 
 def call(Map config = [:]) {
 
-  def nodelist = config.get('NODELIST', env.NODELIST)
-  def context = config.get('context', 'test/' + env.STAGE_NAME)
-  def description = config.get('description', env.STAGE_NAME)
+  String nodelist = config.get('NODELIST', env.NODELIST)
+  String context = config.get('context', 'test/' + env.STAGE_NAME)
+  String description = config.get('description', env.STAGE_NAME)
  
   Map stage_info = parseStageInfo(config)
 
   provisionNodes NODELIST: nodelist,
                  node_count: stage_info['node_count'],
-                 distro: stage_info['target'],
-                 inst_repos: config['inst_repos'],
-                 inst_rpms: config['inst_rpms']
+                 distro: stage_info['ci_target'],
+                 inst_repos: config.get('inst_repos', ''),
+                 inst_rpms: config.get('inst_rpms', '')
 
-  def stashes = []
+  List stashes = []
   if (config['stashes']) {
     stashes = config['stashes']
   } else {

--- a/vars/getDAOSPackages.groovy
+++ b/vars/getDAOSPackages.groovy
@@ -24,5 +24,6 @@ String call(String distro, String next_version) {
     if (distro.startsWith('ubuntu20')) {
         return pkgs + "=" + daosPackagesVersion(distro, next_version)
     }
+    String ret_str = pkgs + "-" + daosPackagesVersion(distro, next_version)
     return pkgs + "-" + daosPackagesVersion(distro, next_version)
 }

--- a/vars/getDAOSPackages.groovy
+++ b/vars/getDAOSPackages.groovy
@@ -24,6 +24,5 @@ String call(String distro, String next_version) {
     if (distro.startsWith('ubuntu20')) {
         return pkgs + "=" + daosPackagesVersion(distro, next_version)
     }
-    String ret_str = pkgs + "-" + daosPackagesVersion(distro, next_version)
     return pkgs + "-" + daosPackagesVersion(distro, next_version)
 }

--- a/vars/hwDistroTarget.groovy
+++ b/vars/hwDistroTarget.groovy
@@ -15,8 +15,12 @@ String hw_distro(String size) {
     //'leap15
     //'centos7
     //'centos8
+    String distro = 'centos7'
+    if (params.CI_HARDWARE_DISTRO) {
+        distro = params.CI_HARDWARE_DISTRO
+    }
     return cachedCommitPragma('Func-hw-test-' + size + '-distro',
-                              cachedCommitPragma('Func-hw-test-distro', 'centos7'))
+                              cachedCommitPragma('Func-hw-test-distro', distro))
 }
 
 String call() {

--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -64,16 +64,24 @@ def call(Map config = [:]) {
       echo "Could not determine target in ${env.STAGE_NAME}, defaulting to EL7"
     }
   }
+  String new_ci_target = params['CI_' +
+                                result['target'].toString().toUpperCase() +
+                                '_TARGET']
+  if (new_ci_target) {
+    result['ci_target'] = new_ci_target
+  } else {
+    result['ci_target'] = result['target']
+  }
 
-  if (result['target'].startsWith('el') ||
-      result['target'].startsWith('centos')) {
+  if (result['ci_target'].startsWith('el') ||
+      result['ci_target'].startsWith('centos')) {
     result['java_pkg'] = 'java-1.8.0-openjdk'
-  } else if (result['target'].startsWith('ubuntu')) {
+  } else if (result['ci_target'].startsWith('ubuntu')) {
     result['java_pkg'] = 'openjdk-8-jdk'
-  } else if (result['target'].startsWith('leap')) {
+  } else if (result['ci_target'].startsWith('leap')) {
     result['java_pkg'] = 'java-1_8_0-openjdk'
   } else {
-    error 'Java package not known for ' + result['target']
+    error 'Java package not known for ' + result['ci_target']
   }
 
   result['compiler'] = 'gcc'
@@ -227,7 +235,13 @@ def call(Map config = [:]) {
       }
     }
 
-  } // if (stage_name.contains('Functional'))
+    // if (stage_name.contains('Functional'))
+  } else if (stage_name.contains('Storage')) {
+    if (env.NODELIST) {
+      List node_list = env.NODELIST.split(',')
+      result['node_count'] = node_list.size()
+    }
+  } // else if (stage_name.contains('Storage'))
   if (config['test']) {
     result['test'] = config['test']
   }

--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -45,10 +45,11 @@
 */
 def call(Map config = [:]) {
 
-  def nodeString = config['NODELIST']
-  def node_list = config['NODELIST'].split(',')
-  def node_max_cnt = node_list.size()
-  def node_cnt = node_max_cnt
+  String nodeString = config['NODELIST']
+  List node_list = config['NODELIST'].split(',')
+  int node_max_cnt = node_list.size()
+  int node_cnt = node_max_cnt
+  String repo_type = config.get('repo_type', 'stable')
   Map new_config = config
   if (config['node_count']) {
     // Matrix builds pass requested node count as a string
@@ -75,8 +76,8 @@ def call(Map config = [:]) {
       return node_cnt
   }
 
-  def distro_type = 'el7'
-  def distro = config.get('distro', 'el7')
+  String distro_type = 'el7'
+  String distro = config.get('distro', 'el7')
   if (distro.startsWith("centos8") || distro.startsWith("el8")) {
     distro_type = 'el8'
   } else if (distro.startsWith("sles") || distro.startsWith("leap") ||
@@ -90,13 +91,10 @@ def call(Map config = [:]) {
       distro_type = 'ubuntu'
   }
 
-  def inst_rpms = config.get('inst_rpms', '')
-  def inst_repos = config.get('inst_repos','')
+  String inst_rpms = config.get('inst_rpms', '')
+  String inst_repos = config.get('inst_repos','')
 
-  def repository_g = ''
-  def repository_l = ''
-
-  def gpg_key_urls = []
+  List gpg_key_urls = []
   if (env.DAOS_STACK_REPO_SUPPORT != null) {
      gpg_key_urls.add(env.DAOS_STACK_REPO_SUPPORT + 'RPM-GPG-KEY-CentOS-7')
      gpg_key_urls.add(env.DAOS_STACK_REPO_SUPPORT +
@@ -109,42 +107,6 @@ def call(Map config = [:]) {
        gpg_key_urls.add(env.DAOS_STACK_REPO_SUPPORT +
                         env.DAOS_STACK_REPO_PUB_KEY)
      }
-  }
-  if (env.REPOSITORY_URL != null) {
-    if (distro_type == 'el7') {
-        if (env.DAOS_STACK_EL_7_GROUP_REPO != null) {
-            repository_g = env.REPOSITORY_URL + env.DAOS_STACK_EL_7_GROUP_REPO
-        }
-        if (env.DAOS_STACK_EL_7_LOCAL_REPO != null) {
-            repository_l = env.REPOSITORY_URL + env.DAOS_STACK_EL_7_LOCAL_REPO
-        }
-    } else if (distro_type == 'el8') {
-        if (env.DAOS_STACK_EL_8_GROUP_REPO != null) {
-            repository_g = env.REPOSITORY_URL + env.DAOS_STACK_EL_8_GROUP_REPO
-        }
-        if (env.DAOS_STACK_EL_8_LOCAL_REPO != null) {
-            repository_l = env.REPOSITORY_URL + env.DAOS_STACK_EL_8_LOCAL_REPO
-        }
-    } else if (distro.startsWith("sles15")) {
-        if (env.DAOS_STACK_SLES_15_GROUP_REPO != null) {
-            repository_g = env.REPOSITORY_URL +
-                env.DAOS_STACK_SLES_15_GROUP_REPO
-        }
-        if (env.DAOS_STACK_SLES_15_LOCAL_REPO != null) {
-            repository_l = env.REPOSITORY_URL +
-                env.DAOS_STACK_SLES_15_LOCAL_REPO
-        }
-    }  else if (distro.startsWith("leap15") ||
-                distro.startsWith("opensuse15")) {
-        if (env.DAOS_STACK_LEAP_15_GROUP_REPO != null) {
-            repository_g = env.REPOSITORY_URL +
-                env.DAOS_STACK_LEAP_15_GROUP_REPO
-        }
-        if (env.DAOS_STACK_LEAP_15_LOCAL_REPO != null) {
-            repository_l = env.REPOSITORY_URL +
-                env.DAOS_STACK_LEAP_15_LOCAL_REPO
-        }
-    }
   }
 
   if (!fileExists('ci/provisioning/log_cleanup.sh') ||
@@ -180,7 +142,6 @@ def call(Map config = [:]) {
                       'GPG_KEY_URLS="' + gpg_key_urls.join(' ') + '" ' +
                       'ci/provisioning/post_provision_config.sh'
   new_config['post_restore'] = provision_script
-
   try {
     def rc = provisionNodesSystem(new_config)
     if (rc != 0) {

--- a/vars/rpmTestVersion.groovy
+++ b/vars/rpmTestVersion.groovy
@@ -11,7 +11,7 @@
  */
 
 boolean call() {
-    if (params.CI_NOBUILD) {
+    if (params.CI_RPM_TEST_VERSION) {
         return params.CI_RPM_TEST_VERSION
     }
     return cachedCommitPragma('RPM-test-version')

--- a/vars/rpmTestVersion.groovy
+++ b/vars/rpmTestVersion.groovy
@@ -11,5 +11,8 @@
  */
 
 boolean call() {
+    if (params.CI_NOBUILD) {
+        return params.CI_RPM_TEST_VERSION
+    }
     return cachedCommitPragma('RPM-test-version')
 }

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -22,15 +22,27 @@ String run_default_skipped_stage(String stage) {
 }
 
 boolean is_pr() {
+    if (params.CI_MORE_FUNCTIONAL_PR_TESTS) {
+        return false
+    }
     return env.CHANGE_ID
 }
 
 boolean skip_ftest(String distro, String target_branch) {
+    // Pragmas have highest priority
     if (run_default_skipped_stage('func-test-' + distro)) {
         // Forced to run due to a (Skip) pragma set to false
         return false
     }
-    return distro == 'ubuntu20' ||
+    // If a parameter exists, it is the next priority.
+    boolean ci_func_distro_test =
+      params.containsKey('CI_FUNCTIONAL_' + distro + '_TEST')
+    boolean params_value = false
+    if (ci_func_distro_test) {
+        params_value = ! params['CI_FUNCTIONAL_' + distro + '_TEST']
+    }
+    return params_value ||
+           distro == 'ubuntu20' ||
            skip_stage_pragma('func-test') ||
            skip_stage_pragma('func-test-vm') ||
            ! testsInStage() ||
@@ -41,7 +53,13 @@ boolean skip_ftest(String distro, String target_branch) {
 }
 
 boolean skip_ftest_hw(String size, String target_branch) {
+    boolean ci_size_test = params.containsKey('CI_' + size + '_TEST')
+    boolean params_value = false
+    if (ci_size_test) {
+        params_value = ! params['CI_' + size + '_TEST']
+    }
     return env.DAOS_STACK_CI_HARDWARE_SKIP == 'true' ||
+           params_value ||
            skip_stage_pragma('func-test') ||
            skip_stage_pragma('func-hw-test-' + size) ||
            ! testsInStage() ||
@@ -52,7 +70,13 @@ boolean skip_ftest_hw(String size, String target_branch) {
 }
 
 boolean skip_if_unstable() {
-    if (cachedCommitPragma('Allow-unstable-test').toLowerCase() == 'true' ||
+    if (params.CI_ALLOW_UNSTABLE_TEST) {
+        println('skip if unstable - params.CI_ALLOW_UNSTABLE_TEST is true')
+    } else {
+        println('skip if unstable - params.CI_ALLOW_UNSTABLE_TEST is true')
+    }
+    if (params.CI_ALLOW_UNSTABLE_TEST ||
+        cachedCommitPragma('Allow-unstable-test').toLowerCase() == 'true' ||
         env.BRANCH_NAME == 'master' ||
         env.BRANCH_NAME.startsWith("weekly-testing") ||
         env.BRANCH_NAME.startsWith("release/")) {
@@ -66,7 +90,8 @@ boolean skip_if_unstable() {
 }
 
 boolean skip_build_on_centos7_gcc(String target_branch) {
-    return skip_stage_pragma('build-centos7-gcc') ||
+    return params.CI_BUILD_PACKAGES_ONLY ||
+           skip_stage_pragma('build-centos7-gcc') ||
            (docOnlyChange(target_branch) &&
             prRepos('centos7') == '') ||
            quickFunctional()
@@ -96,77 +121,102 @@ boolean call(Map config = [:]) {
         case "Build":
             // always build branch landings as we depend on lastSuccessfulBuild
             // always having RPMs in it
-            return (env.BRANCH_NAME != target_branch) &&
+            return params.CI_NOBUILD ||
+                   (env.BRANCH_NAME != target_branch) &&
                    skip_stage_pragma('build') ||
                    rpmTestVersion() != ''
+        case "Build RPM on CentOS 7":
+            return params.CI_RPM_centos7_NOBUILD ||
+                   (docOnlyChange(target_branch) &&
+                    prRepos('centos7') == '') ||
+                   skip_stage_pragma('build-centos7-rpm')
+        case "Build RPM on CentOS 8":
+            return params.CI_RPM_centos8_NOBUILD ||
+                   (docOnlyChange(target_branch) &&
+                    prRepos('centos8') == '') ||
+                   skip_stage_pragma('build-centos7-rpm')
         case "Build RPM on Leap 15":
-            return target_branch == 'weekly-testing' ||
+            return params.CI_RPM_leap15_NOBUILD ||
+                   target_branch == 'weekly-testing' ||
                    (docOnlyChange(target_branch) &&
                     prRepos('leap15') == '') ||
                    skip_stage_pragma('build-leap15-rpm')
         case "Build DEB on Ubuntu 20.04":
-            return target_branch == 'weekly-testing' ||
+            return params.CI_RPM_ubuntu20_NOBUILD ||
+                   target_branch == 'weekly-testing' ||
                    (docOnlyChange(target_branch) &&
                     prRepos('ubuntu20') == '') ||
                    skip_stage_pragma('build-ubuntu20-rpm')
         case "Build on CentOS 7":
             return skip_build_on_centos7_gcc(target_branch)
         case "Build on CentOS 7 Bullseye":
-            return env.NO_CI_TESTING == 'true' ||
+            return params.CI_BUILD_PACKAGES_ONLY ||
+                   env.NO_CI_TESTING == 'true' ||
                    skip_stage_pragma('bullseye', 'true') ||
                    (docOnlyChange(target_branch) &&
                     prRepos('centos7') == '') ||
                    quickFunctional()
         case "Build on CentOS 7 debug":
-            return skip_stage_pragma('build-centos7-gcc-debug') ||
+            return params.CI_BUILD_PACKAGES_ONLY ||
+                   skip_stage_pragma('build-centos7-gcc-debug') ||
                    (docOnlyChange(target_branch) &&
                     prRepos('centos7') == '') ||
                    quickBuild()
         case "Build on CentOS 7 release":
-            return skip_stage_pragma('build-centos7-gcc-release') ||
+            return params.CI_BUILD_PACKAGES_ONLY ||
+                   skip_stage_pragma('build-centos7-gcc-release') ||
                    (docOnlyChange(target_branch) &&
                     prRepos('centos7') == '') ||
                    quickBuild()
         case "Build on CentOS 7 with Clang":
         case "Build on CentOS 7 with Clang debug":
-            return env.BRANCH_NAME != target_branch ||
+            return params.CI_BUILD_PACKAGES_ONLY ||
+                   env.BRANCH_NAME != target_branch ||
                    (docOnlyChange(target_branch) &&
                     prRepos('centos7') == '') ||
                    quickBuild()
         case "Build on Ubuntu 20.04":
-            return env.BRANCH_NAME != target_branch ||
+            return params.CI_BUILD_PACKAGES_ONLY ||
+                   env.BRANCH_NAME != target_branch ||
                    (docOnlyChange(target_branch) &&
                     prRepos('ubuntu20') == '') ||
                    quickBuild()
         case "Build on Leap 15 with Clang":
-            return env.BRANCH_NAME != target_branch ||
+            return params.CI_BUILD_PACKAGES_ONLY ||
+                   env.BRANCH_NAME != target_branch ||
                    (docOnlyChange(target_branch) &&
                     prRepos('leap15') == '') ||
                    quickBuild()
         case "Build on CentOS 8":
-            return skip_stage_pragma('build-centos8-gcc-dev') ||
+            return params.CI_BUILD_PACKAGES_ONLY ||
+                   skip_stage_pragma('build-centos8-gcc-dev') ||
                    (docOnlyChange(target_branch) &&
                     prRepos('centos8') == '') ||
                    quickBuild()
         case "Build on Ubuntu 20.04 with Clang":
-            return target_branch == 'weekly-testing' ||
+            return params.CI_BUILD_PACKAGES_ONLY ||
+                   target_branch == 'weekly-testing' ||
                    skip_stage_pragma('build-ubuntu-clang') ||
                    (docOnlyChange(target_branch) &&
                     prRepos('ubuntu20') == '') ||
                    quickBuild()
         case "Build on Leap 15":
-            return skip_stage_pragma('build-leap15-gcc') ||
+            return params.CI_BUILD_PACKAGES_ONLY ||
+                   skip_stage_pragma('build-leap15-gcc') ||
                    (docOnlyChange(target_branch) &&
                     prRepos('leap15') == '') ||
                    quickBuild()
         case "Build on Leap 15 with Intel-C and TARGET_PREFIX":
-            return target_branch == 'weekly-testing' ||
+            return params.CI_BUILD_PACKAGES_ONLY ||
+                   target_branch == 'weekly-testing' ||
                    skip_stage_pragma('build-leap15-icc') ||
                    (docOnlyChange(target_branch) &&
                     prRepos('leap15') == '') ||
                    quickBuild()
         case "Unit Tests":
             return  env.NO_CI_TESTING == 'true' ||
+                    params.CI_BUILD_PACKAGES_ONLY ||
+                    params.CI_NOBUILD ||
                     quickBuild() ||
                     skip_stage_pragma('build') ||
                     rpmTestVersion() != '' ||
@@ -178,9 +228,11 @@ boolean call(Map config = [:]) {
         case "Unit Test Bullseye":
             return skip_stage_pragma('bullseye', 'true')
         case "Unit Test with memcheck":
-            return skip_stage_pragma('unit-test-memcheck')
+            return ! params.CI_UNIT_TEST_MEMCHECK ||
+                   skip_stage_pragma('unit-test-memcheck')
         case "Unit Test":
-            return skip_stage_pragma('unit-test') ||
+            return params.CI_UNIT_TEST ||
+                   skip_stage_pragma('unit-test') ||
                    skip_stage_pragma('run_test')
         case "Test":
             return env.NO_CI_TESTING == 'true' ||
@@ -195,7 +247,9 @@ boolean call(Map config = [:]) {
             return skip_stage_pragma('vagrant-test', 'true') &&
                    ! env.BRANCH_NAME.startsWith('weekly-testing')
         case "Coverity on CentOS 7":
-            return skip_stage_pragma('coverity-test') ||
+            return params.CI_BUILD_PACKAGES_ONLY ||
+                   params.CI_NOBUILD ||
+                   skip_stage_pragma('coverity-test') ||
                    quickFunctional() ||
                    docOnlyChange(target_branch) ||
                    skip_stage_pragma('build')
@@ -208,14 +262,16 @@ boolean call(Map config = [:]) {
         case "Functional on Ubuntu 20.04":
             return skip_ftest('ubuntu20', target_branch)
         case "Test CentOS 7 RPMs":
-            return target_branch == 'weekly-testing' ||
+            return ! params.CI_RPMS_el7_TEST ||
+                   target_branch == 'weekly-testing' ||
                    skip_stage_pragma('test') ||
                    skip_stage_pragma('test-centos-rpms') ||
                    docOnlyChange(target_branch) ||
                    quickFunctional()
         case "Scan CentOS 7 RPMs":
-            return target_branch == 'weekly-testing' ||
-                   skip_stage_pragma('scan-centos-rpms', 'true') ||
+            return ! params.CI_SCAN_RPMS_el7_TEST ||
+                   target_branch == 'weekly-testing' ||
+                   skip_stage_pragma('scan-centos-rpms') ||
                    docOnlyChange(target_branch) ||
                    quickFunctional()
         case "Test Hardware":

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -70,11 +70,6 @@ boolean skip_ftest_hw(String size, String target_branch) {
 }
 
 boolean skip_if_unstable() {
-    if (params.CI_ALLOW_UNSTABLE_TEST) {
-        println('skip if unstable - params.CI_ALLOW_UNSTABLE_TEST is true')
-    } else {
-        println('skip if unstable - params.CI_ALLOW_UNSTABLE_TEST is true')
-    }
     if (params.CI_ALLOW_UNSTABLE_TEST ||
         cachedCommitPragma('Allow-unstable-test').toLowerCase() == 'true' ||
         env.BRANCH_NAME == 'master' ||
@@ -134,7 +129,7 @@ boolean call(Map config = [:]) {
             return params.CI_RPM_centos8_NOBUILD ||
                    (docOnlyChange(target_branch) &&
                     prRepos('centos8') == '') ||
-                   skip_stage_pragma('build-centos7-rpm')
+                   skip_stage_pragma('build-centos8-rpm')
         case "Build RPM on Leap 15":
             return params.CI_RPM_leap15_NOBUILD ||
                    target_branch == 'weekly-testing' ||
@@ -231,15 +226,6 @@ boolean call(Map config = [:]) {
             return ! params.CI_UNIT_TEST_MEMCHECK ||
                    skip_stage_pragma('unit-test-memcheck')
         case "Unit Test":
-                   if (params.CI_UNIT_TEST) {
-                       println("CI_UNIT_TEST found!")
-                   }
-                   if (skip_stage_pragma('unit-test')) {
-                       println("Unit test skip requested")
-                   }
-                   if (skip_stage_pragma('run-test')) {
-                       println("Run test skip requested")
-                   }
             return params.CI_UNIT_TEST ||
                    skip_stage_pragma('unit-test') ||
                    skip_stage_pragma('run_test')

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -30,7 +30,7 @@ boolean is_pr() {
 
 // If a parameter does not exist, we need to set a default
 // value for it.
-boolean params_value(String parameter, boolean def_value {
+boolean params_value(String parameter, boolean def_value) {
     boolean ci_param_exists = params.containsKey(parameter)
     boolean params_value = def_value
     if (ci_param_exists) {

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -116,7 +116,7 @@ boolean call(Map config = [:]) {
         case "Build":
             // always build branch landings as we depend on lastSuccessfulBuild
             // always having RPMs in it
-            return params.CI_NOBUILD ||
+            return params.CI_RPM_TEST_VERSION ||
                    (env.BRANCH_NAME != target_branch) &&
                    skip_stage_pragma('build') ||
                    rpmTestVersion() != ''
@@ -211,7 +211,7 @@ boolean call(Map config = [:]) {
         case "Unit Tests":
             return  env.NO_CI_TESTING == 'true' ||
                     params.CI_BUILD_PACKAGES_ONLY ||
-                    params.CI_NOBUILD ||
+                    params.CI_RPM_TEST_VERSION ||
                     quickBuild() ||
                     skip_stage_pragma('build') ||
                     rpmTestVersion() != '' ||
@@ -243,7 +243,7 @@ boolean call(Map config = [:]) {
                    ! env.BRANCH_NAME.startsWith('weekly-testing')
         case "Coverity on CentOS 7":
             return params.CI_BUILD_PACKAGES_ONLY ||
-                   params.CI_NOBUILD ||
+                   params.CI_RPM_TEST_VERSION ||
                    skip_stage_pragma('coverity-test') ||
                    quickFunctional() ||
                    docOnlyChange(target_branch) ||

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -138,7 +138,7 @@ boolean call(Map config = [:]) {
                     prRepos('leap15') == '') ||
                    skip_stage_pragma('build-leap15-rpm')
         case "Build DEB on Ubuntu 20.04":
-            return params_value('CI_RPM_ubuntu20_NOBUILD' false) ||
+            return params_value('CI_RPM_ubuntu20_NOBUILD', false) ||
                    target_branch == 'weekly-testing' ||
                    (docOnlyChange(target_branch) &&
                     prRepos('ubuntu20') == '') ||

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -32,11 +32,11 @@ boolean is_pr() {
 // value for it.
 boolean params_value(String parameter, boolean def_value) {
     boolean ci_param_exists = params.containsKey(parameter)
-    boolean params_value = def_value
+    boolean param_value = def_value
     if (ci_param_exists) {
-        params_value = params[parameter]
+        param_value = params[parameter]
     }
-    return def_value
+    return param_value
 }
 
 boolean skip_ftest(String distro, String target_branch) {

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -224,10 +224,10 @@ boolean call(Map config = [:]) {
         case "Unit Test Bullseye":
             return skip_stage_pragma('bullseye', 'true')
         case "Unit Test with memcheck":
-            return params_value('CI_UNIT_TEST_MEMCHECK', true) ||
+            return ! params_value('CI_UNIT_TEST_MEMCHECK', true) ||
                    skip_stage_pragma('unit-test-memcheck')
         case "Unit Test":
-            return params_value('CI_UNIT_TEST', true) ||
+            return ! params_value('CI_UNIT_TEST', true) ||
                    skip_stage_pragma('unit-test') ||
                    skip_stage_pragma('run_test')
         case "Test":

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -231,6 +231,15 @@ boolean call(Map config = [:]) {
             return ! params.CI_UNIT_TEST_MEMCHECK ||
                    skip_stage_pragma('unit-test-memcheck')
         case "Unit Test":
+                   if (params.CI_UNIT_TEST) {
+                       println("CI_UNIT_TEST found!")
+                   }
+                   if (skip_stage_pragma('unit-test')) {
+                       println("Unit test skip requested")
+                   }
+                   if (skip_stage_pragma('run-test')) {
+                       println("Run test skip requested")
+                   }
             return params.CI_UNIT_TEST ||
                    skip_stage_pragma('unit-test') ||
                    skip_stage_pragma('run_test')

--- a/vars/storagePrepTest.groovy
+++ b/vars/storagePrepTest.groovy
@@ -77,11 +77,6 @@ def call(Map config = [:]) {
     return
   }
 
-  Boolean test_rpms = false
-  if (config['test_rpms'] == "true") {
-    test_rpms = true
-  }
-
   config['script'] = 'export NODE_COUNT="' + stage_info['node_count'] + '"\n ' +
                      'export OPERATIONS_EMAIL="' +
                          env.OPERATIONS_EMAIL + '"\n ' +

--- a/vars/storagePrepTest.groovy
+++ b/vars/storagePrepTest.groovy
@@ -1,7 +1,7 @@
-// vars/scanRpms.groovy
+// vars/storagePrepTest.groovy
 
   /**
-   * scanRpms step method
+   * storagePrepTest step method
    *
    * @param config Map of parameters passed
    *
@@ -18,8 +18,6 @@
    *     Or the default name has to be changed in a way that is compatible
    *     with a future Matrix implementation.
    *
-   * config['daos_pkg_version']  Version of DAOS package.  Required.
-   *
    * config['description']       Description to report for SCM status.
    *                             Default env.STAGE_NAME.
    *
@@ -29,55 +27,71 @@
    * config['ignore_failure']    Ignore test failures.  Default false.
    * config['inst_repos']        Additional repositories to use.  Optional.
    *
-   * config['inst_rpms']         Additional rpms to install.
-   *                             Default 'clamav clamav-devel'
+   * config['inst_rpms']         Additional rpms to install.  Optional
    *
-   * config['junit_files']       Junit files to return.
-   *                             Default 'maldetect.xml'
+   * config['junit_files']       Junit files to return.  Optional.
    *
    * config['NODELIST']          NODELIST of nodes to run tests on.
    *                             Default env.NODELIST
+   *
+   * config['node_count']        Count of nodes that will actually be used
+   *                             the test.  Default will be based on the
+   *                             enviroment variables for the stage.
+   *
+   * config['stashes']           List of stashes to use.  Default will be
+   *                             baed on the environment variables for the
+   *                             stage.
    *
    * config['target']            Target distribution, such as 'centos7',
    *                             'leap15'.  Default based on parsing
    *                             environment variables for the stage.
    *
-   * config['test_script']       Script to build RPMs. 
-   *                             Default 'ci/rpm_scan_daos_test.sh'.
+   * config['test_rpms']         Set to true to test RPMs being built.
+   *                             Default env.TEST_RPMS.
+   *
+   * config['test_tag']          Avocado tag to test. (Not currently used)
+   *                             Default determined by parseStageInfo().
    *
    */
 
 def call(Map config = [:]) {
 
-  if (!config['daos_pkg_version']) {
-    error 'daos_pkg_version is required.'
-  }
-
   String nodelist = config.get('NODELIST', env.NODELIST)
   String context = config.get('context', 'test/' + env.STAGE_NAME)
   String description = config.get('description', env.STAGE_NAME)
-  String test_script = config.get('test_script', 'ci/rpm_scan_daos_test.sh')
-  String inst_rpms = config.get('inst_rpms', 'clamav clamav-devel')
-
+ 
   Map stage_info = parseStageInfo(config)
 
   provisionNodes NODELIST: nodelist,
-                 node_count: 1,
+                 node_count: stage_info['node_count'],
                  distro: stage_info['ci_target'],
                  inst_repos: config.get('inst_repos', ''),
-                 inst_rpmms: inst_rpms
+                 inst_rpms: config.get('inst_rpms', '')
 
-  String full_test_script = 'export DAOS_PKG_VERSION=' +
-                         config['daos_pkg_version'] + '\n' +
-                         test_script
+  Map params = [:]
+  params['context'] = context
+  params['description'] = description
 
-  def junit_files = config.get('junit_files', null)
-  def failure_artifacts = config.get('failure_artifacts', env.STAGE_NAME)
-  def ignore_failure = config.get('ignore_failure', false)
-  runTest script: full_test_script,
-          junit_files: junit_files,
-          failure_artifacts: env.STAGE_NAME,
-          ignore_failure: ignore_failure,
-          description: description,
-          context: context
+  if (!fileExists('ci/storage/test_main.sh')) {
+    println("No storage Prep script found!")
+    return
+  }
+
+  Boolean test_rpms = false
+  if (config['test_rpms'] == "true") {
+    test_rpms = true
+  }
+
+  config['script'] = 'export NODE_COUNT="' + stage_info['node_count'] + '"\n ' +
+                     'export OPERATIONS_EMAIL="' +
+                         env.OPERATIONS_EMAIL + '"\n ' +
+                     'export DAOS_PKG_VERSION=' +
+                         daosPackagesVersion("1000") + '\n' +
+                     'ci/storage/test_main.sh'
+                                     
+  if (!config['failure_artifacts']) {
+    config['failure_artifacts'] = env.STAGE_NAME
+  }
+
+  runTest(config)
 }

--- a/vars/testRpm.groovy
+++ b/vars/testRpm.groovy
@@ -53,21 +53,21 @@ def call(Map config = [:]) {
     error 'daos_pkg_version is required.'
   }
 
-  def nodelist = config.get('NODELIST', env.NODELIST)
-  def context = config.get('context', 'test/' + env.STAGE_NAME)
-  def description = config.get('description', env.STAGE_NAME)
-  def test_script = config.get('test_script', 'ci/rpm/test_daos.sh')
+  String nodelist = config.get('NODELIST', env.NODELIST)
+  String context = config.get('context', 'test/' + env.STAGE_NAME)
+  String description = config.get('description', env.STAGE_NAME)
+  String test_script = config.get('test_script', 'ci/rpm/test_daos.sh')
 
   Map stage_info = parseStageInfo(config)
 
   provisionNodes NODELIST: nodelist,
                  node_count: 1,
                  profile: config.get('profile', 'daos_ci'),
-                 distro: stage_info['target'],
+                 distro: stage_info['ci_target'],
                  inst_repos: config.get('inst_repos', ''),
                  inst_rpms: config.get('inst_rpms', '')
 
-  def full_test_script = 'export DAOS_PKG_VERSION=' +
+  String full_test_script = 'export DAOS_PKG_VERSION=' +
                          config['daos_pkg_version'] + '\n' +
                          test_script
 

--- a/vars/unitTest.groovy
+++ b/vars/unitTest.groovy
@@ -69,8 +69,8 @@
 
 def call(Map config = [:]) {
 
-  def nodelist = config.get('NODELIST', env.NODELIST)
-  def test_script = config.get('test_script', 'ci/unit/test_main.sh')
+  String nodelist = config.get('NODELIST', env.NODELIST)
+  String test_script = config.get('test_script', 'ci/unit/test_main.sh')
 
   Map stage_info = parseStageInfo(config)
 
@@ -84,16 +84,16 @@ def call(Map config = [:]) {
 
   provisionNodes NODELIST: nodelist,
                  node_count: stage_info['node_count'],
-                 distro: stage_info['target'],
-                 inst_repos: config['inst_repos'],
+                 distro: stage_info['ci_target'],
+                 inst_repos: config.get('inst_repos', ''),
                  inst_rpms: inst_rpms
 
-  def target_stash = "${stage_info['target']}-${stage_info['compiler']}"
+  String target_stash = "${stage_info['target']}-${stage_info['compiler']}"
   if (stage_info['build_type']) {
     target_stash += '-' + stage_info['build_type']
   }
 
-  def stashes = []
+  List stashes = []
   if (config['stashes']) {
     stashes = config['stashes']
   } else {
@@ -104,7 +104,7 @@ def call(Map config = [:]) {
 
   if (stage_info['compiler'] == 'covc') {
 
-    def tools_url = env.JENKINS_URL +
+    String tools_url = env.JENKINS_URL +
                     'job/daos-stack/job/tools/job/master' +
                     '/lastSuccessfulBuild/artifact/'
     httpRequest url: tools_url + 'bullseyecoverage-linux.tar',
@@ -123,8 +123,8 @@ def call(Map config = [:]) {
   params['description'] = config.get('description', env.STAGE_NAME)
   params['ignore_failure'] = config.get('ignore_failure', false)
 
-  def time = config.get('timeout_time', 120) as int
-  def unit = config.get('timeout_unit', 'MINUTES')
+  int time = config.get('timeout_time', 120) as int
+  String unit = config.get('timeout_unit', 'MINUTES')
 
   timeout(time: time, unit: unit) {
     runTest params


### PR DESCRIPTION
Separate out a 'ci_target' from a build 'target' to allow more easily
running tests on newer pre-built CI images.

dockerBuildArgs.groovy:
   Add CentOS 8 special app stream repo
   Fix missing variable declaration

parseStageInfo.groovy
   Set the 'ci_target' member for node provisioning

rpmTestVersion.goovy
   Allow a build parameter for the version

skipStage.groovy
   Allow build paramters to select tests to skip.

functionalTest.groovy:
scanRpms.groovy:
testRpm.groovy:
unitTest.groovy
   Now use 'ci_target' for node provisioning

provisionNodes.groovy:
   Fix some declarations to be more specific types
   Remove some dead code

storagePrepTest.groovy:
   Stub for doing a Daos Storage Prep

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>