### PR TITLE
DAOS-8161 tests: Enabling VMD testing in CI HW clusters

### DIFF
--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -141,7 +141,7 @@ def call(Map config = [:]) {
     if (stage_name.contains('Hardware')) {
       cluster_size = 'hw,large'
       result['pragma_suffix'] = '-hw-large'
-      result['ftest_arg'] = '--nvme=auto:Optane'
+      result['ftest_arg'] = '--nvme=auto_vmd_mixed:Optane'
       if (stage_name.contains('Small')) {
         result['node_count'] = 3
         cluster_size = 'hw,small'


### PR DESCRIPTION
Changing the default launch.py --nvme argument for CI HW clusters to
enable testing with both non-VMD NVMe drives and VMD NVMe drives.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>