### PR TITLE
CORCI-1100 build: Updating to python3-avocado RPMs

### DIFF
--- a/vars/provisionNodesV1.groovy
+++ b/vars/provisionNodesV1.groovy
@@ -261,12 +261,12 @@ EOF'''
                                                  python36-nose                                 \
                                                  python36-pip valgrind                         \
                                                  python36-paramiko                             \
-                                                 python2-avocado                               \
-                                                 python2-avocado-plugins-output-html           \
-                                                 python2-avocado-plugins-varianter-yaml-to-mux \
+                                                 python3-avocado                               \
+                                                 python3-avocado-plugins-output-html           \
+                                                 python3-avocado-plugins-varianter-yaml-to-mux \
                                                  libcmocka python-pathlib                      \
-                                                 python2-numpy git                             \
-                                                 python2-clustershell                          \
+                                                 python3-numpy git                             \
+                                                 python3-clustershell                          \
                                                  golang-bin ipmctl ndctl'''
     if (inst_rpms) {
       provision_script += ' ' + inst_rpms

--- a/vars/testsInStage.groovy
+++ b/vars/testsInStage.groovy
@@ -24,8 +24,7 @@ boolean call() {
               script: """if \${UNIT_TEST:-false}; then
                              exit 0
                          fi
-                         dnf -y install python3-avocado
                          cd src/tests/ftest
-                         ./launch.py --list """ + parseStageInfo()['test_tag'],
+                         ./list_tests.py """ + parseStageInfo()['test_tag'],
               returnStatus: true) == 0
 }

--- a/vars/testsInStage.groovy
+++ b/vars/testsInStage.groovy
@@ -25,6 +25,6 @@ boolean call() {
                              exit 0
                          fi
                          cd src/tests/ftest
-                         ./list_tests.py """ + parseStageInfo()['test_tag'],
+                         ./launch.py --list """ + parseStageInfo()['test_tag'],
               returnStatus: true) == 0
 }

--- a/vars/testsInStage.groovy
+++ b/vars/testsInStage.groovy
@@ -25,6 +25,6 @@ boolean call() {
                              exit 0
                          fi
                          cd src/tests/ftest
-                         ./launch.py --list """ + parseStageInfo()['test_tag'],
+                         ./list_tests.py """ + parseStageInfo()['test_tag'],
               returnStatus: true) == 0
 }

--- a/vars/testsInStage.groovy
+++ b/vars/testsInStage.groovy
@@ -24,7 +24,8 @@ boolean call() {
               script: """if \${UNIT_TEST:-false}; then
                              exit 0
                          fi
+                         dnf -y install python3-avocado
                          cd src/tests/ftest
-                         ./list_tests.py """ + parseStageInfo()['test_tag'],
+                         ./launch.py --list """ + parseStageInfo()['test_tag'],
               returnStatus: true) == 0
 }


### PR DESCRIPTION
Replacing python2-avocado* RPMs with python3-avocado* RPMs.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>