### PR TITLE
CORCI-1128 build: Adding pr tests to daily runs

### DIFF
--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -183,7 +183,7 @@ def call(Map config = [:]) {
                 if (env.BRANCH_NAME.startsWith("weekly-testing")) {
                   tag = "full_regression"
                 } else {
-                  tag = "daily_regression"
+                  tag = "pr daily_regression"
                 }
               } else {
                 // Must be a PR run


### PR DESCRIPTION
Hardware tests with 'pr' tags do not get run in landing PRs nor daily
PRs.  THese tests will no be included as part of the master daily run.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>