### PR TITLE
CORCI-1097 ci: Clean up returned PR-repos: string

### DIFF
--- a/vars/prRepos.groovy
+++ b/vars/prRepos.groovy
@@ -28,5 +28,5 @@ String call(String distro) {
        error 'prRepos not implemented for ' + distro
     }
     return [repos,
-            cachedCommitPragma('PR-repos')].join(' ')
+            cachedCommitPragma('PR-repos')].join(' ').trim()
 }


### PR DESCRIPTION
To remove any leading/trailing whitespace removed.  This fixes the
problem where we might get a space joined list of empty items returning
one or more spaces instead of an empty string.