### PR TITLE
Package buiding on Leap should be 15.2 still

### DIFF
--- a/vars/packageBuildingPipeline.groovy
+++ b/vars/packageBuildingPipeline.groovy
@@ -556,7 +556,7 @@ def call(Map pipeline_args) {
                             sh label: "Build package",
                                script: '''rm -rf artifacts/leap15/
                                           mkdir -p artifacts/leap15/
-                                          make CHROOT_NAME="opensuse-leap-15.3-x86_64" ''' +
+                                          make CHROOT_NAME="opensuse-leap-15.2-x86_64" ''' +
                                        pipeline_args.get('make args', '') + ' chrootbuild ' +
                                        pipeline_args.get('add_make_targets', '')
                         }
@@ -564,10 +564,10 @@ def call(Map pipeline_args) {
                             success {
                                 catchError(stageResult: 'UNSTABLE', buildResult: 'SUCCESS') {
                                     sh label: "RPM Lint artifacts",
-                                       script: 'rpmlint /var/lib/mock/opensuse-leap-15.3-x86_64/result/*.rpm'
+                                       script: 'rpmlint /var/lib/mock/opensuse-leap-15.2-x86_64/result/*.rpm'
                                 }
                                 sh label: "Collect artifacts",
-                                   script: '''(cd /var/lib/mock/opensuse-leap-15.3-x86_64/result/ &&
+                                   script: '''(cd /var/lib/mock/opensuse-leap-15.2-x86_64/result/ &&
                                               cp -r . $OLDPWD/artifacts/leap15/)\n''' +
                                               pipeline_args.get('add_archiving_cmds', '').replace("<distro>", "leap15") +
                                              '\ncreaterepo artifacts/leap15/'
@@ -583,7 +583,7 @@ def call(Map pipeline_args) {
                             }
                             unsuccessful {
                                 sh label: "Build Log",
-                                   script: '''mockroot=/var/lib/mock/opensuse-leap-15.3-x86_64
+                                   script: '''mockroot=/var/lib/mock/opensuse-leap-15.2-x86_64
                                               ls -l $mockroot/result/
                                               cat $mockroot/result/{root,build}.log
                                               artdir=$PWD/artifacts/leap15

--- a/vars/packageBuildingPipelineDAOS.groovy
+++ b/vars/packageBuildingPipelineDAOS.groovy
@@ -559,7 +559,7 @@ def call(Map pipeline_args) {
                             sh label: "Build package",
                                script: '''rm -rf artifacts/leap15/
                                           mkdir -p artifacts/leap15/
-                                          make CHROOT_NAME="opensuse-leap-15.3-x86_64" ''' +
+                                          make CHROOT_NAME="opensuse-leap-15.2-x86_64" ''' +
                                        pipeline_args.get('make args', '') + ' chrootbuild ' +
                                        pipeline_args.get('add_make_targets', '')
                         }
@@ -567,10 +567,10 @@ def call(Map pipeline_args) {
                             success {
                                 catchError(stageResult: 'UNSTABLE', buildResult: 'SUCCESS') {
                                     sh label: "RPM Lint artifacts",
-                                       script: 'rpmlint /var/lib/mock/opensuse-leap-15.3-x86_64/result/*.rpm'
+                                       script: 'rpmlint /var/lib/mock/opensuse-leap-15.2-x86_64/result/*.rpm'
                                 }
                                 sh label: "Collect artifacts",
-                                   script: '''(cd /var/lib/mock/opensuse-leap-15.3-x86_64/result/ &&
+                                   script: '''(cd /var/lib/mock/opensuse-leap-15.2-x86_64/result/ &&
                                               cp -r . $OLDPWD/artifacts/leap15/)\n''' +
                                               pipeline_args.get('add_archiving_cmds', '').replace("<distro>", "leap15") +
                                              '\ncreaterepo artifacts/leap15/'
@@ -586,7 +586,7 @@ def call(Map pipeline_args) {
                             }
                             unsuccessful {
                                 sh label: "Build Log",
-                                   script: '''mockroot=/var/lib/mock/opensuse-leap-15.3-x86_64
+                                   script: '''mockroot=/var/lib/mock/opensuse-leap-15.2-x86_64
                                               ls -l $mockroot/result/
                                               cat $mockroot/result/{root,build}.log
                                               artdir=$PWD/artifacts/leap15
@@ -596,7 +596,7 @@ def call(Map pipeline_args) {
                             }
                             always {
                                 sh label: "Collect config.log(s)",
-                                   script: '''(if cd /var/lib/mock/opensuse-leap-15.3-x86_64/root/builddir/build/BUILD/*/; then
+                                   script: '''(if cd /var/lib/mock/opensuse-leap-15.2-x86_64/root/builddir/build/BUILD/*/; then
                                                    find . -name configure -printf %h\\\\n | \
                                                    while read dir; do
                                                        if [ ! -f $dir/config.log ]; then
@@ -864,10 +864,10 @@ def call(Map pipeline_args) {
                                           if ! make PR_REPOS="''' + env.JOB_NAME.split('/')[1] +
                                                '@' + env.BRANCH_NAME + ':' + env.BUILD_NUMBER +
                                                ' ' + pipeline_args.get('test_repos', '') + '''" \
-                                               CHROOT_NAME=opensuse-leap-15.3-x86_64            \
+                                               CHROOT_NAME=opensuse-leap-15.2-x86_64            \
                                                -C utils/rpms chrootbuild; then
                                             grep 'No matching package to install'               \
-                                                 /var/lib/mock/opensuse-leap-15.3-x86_64/result/root.log
+                                                 /var/lib/mock/opensuse-leap-15.2-x86_64/result/root.log
                                             # We need to allow failures from missing other packages
                                             # we build for creating an initial set of packages
                                           fi'''
@@ -875,7 +875,7 @@ def call(Map pipeline_args) {
                         post {
                             always {
                                 sh label: "Build Log",
-                                   script: 'cat /var/lib/mock/opensuse-leap-15.3-x86_64/result/{root,build}.log'
+                                   script: 'cat /var/lib/mock/opensuse-leap-15.2-x86_64/result/{root,build}.log'
                             }
                             cleanup {
                                 archiveArtifacts artifacts: 'test_artifacts/**',


### PR DESCRIPTION
We have not completely forward and backward tested 15.3 yet.

This really only matters because of the %{dist} for Leap including the
minor version in it.
