### PR TITLE
Replace %2F in Launchable's build name with -

### DIFF
--- a/vars/functionalTest.groovy
+++ b/vars/functionalTest.groovy
@@ -92,8 +92,8 @@ def call(Map config = [:]) {
 
   withCredentials([string(credentialsId: 'launchable-test', variable: 'LAUNCHABLE_TOKEN')]) {
      sh label: "Send build data",
-        script: """export PATH=$PATH:$HOME/.local/bin
-                   launchable record build --name $BUILD_TAG --source src=."""
+        script: '''export PATH=$PATH:$HOME/.local/bin
+                   launchable record build --name ${BUILD_TAG//%2F/-} --source src=.'''
   }
 
   if (config.get('test_function', "runTestFunctional") ==

--- a/vars/functionalTestPostV2.groovy
+++ b/vars/functionalTestPostV2.groovy
@@ -42,7 +42,7 @@ def call(Map config = [:]) {
         sh label: "Submit test results to Launchable",
            script: 'if ls -l ' + '"' + env.STAGE_NAME + '''"/*/*/xunit1_results.xml 2>/dev/null; then
                         export PATH=$PATH:$HOME/.local/bin
-                        launchable record tests --build $BUILD_TAG pytest ''' +
+                        launchable record tests --build ${BUILD_TAG//%2F/-} pytest ''' +
                                    '"' + env.STAGE_NAME + '''"/*/*/xunit1_results.xml
                     fi'''
     }


### PR DESCRIPTION
/ (or even the URL encoding of it) is not legal in a Launchable build name.