### PR TITLE
Build a dev build if the test tag has "with_fi" in it

### DIFF
--- a/vars/sconsFaultsArgs.groovy
+++ b/vars/sconsFaultsArgs.groovy
@@ -12,8 +12,10 @@
 
 boolean call() {
     // The default build will have BUILD_TYPE=dev; fault injection enabled
-    if (cachedCommitPragma('faults-enabled', 'true').toLowerCase() == 'true' &&
-         !releaseCandidate()) {
+    if (params.TestTag.indexOf("with_fi") >= 0 ||
+        (cachedCommitPragma('faults-enabled', 'true').toLowerCase() == 'true' &&
+         !releaseCandidate()))
+         ) {
         return "BUILD_TYPE=dev"
     } else {
         return "BUILD_TYPE=release"


### PR DESCRIPTION
This is just a hack to be able to enable fault injection until we have a
build parameter dedicated to this.