### PR TITLE
DAOS-623: Install matching version of daos-serialize

### DIFF
--- a/vars/getDAOSPackages.groovy
+++ b/vars/getDAOSPackages.groovy
@@ -26,7 +26,7 @@ String call(String distro, String next_version, String add_daos_pkgs) {
 
     String pkgs
     if (env.TEST_RPMS == 'true') {
-        pkgs = "daos{,-{client,tests,server}" + add_daos_pkgs + "}"
+        pkgs = "daos{,-{client,tests,server,serialize}" + add_daos_pkgs + "}"
     } else {
         pkgs = "daos{,-client}"
     }


### PR DESCRIPTION
Ensure the same version of the daos-serialize RPM that was built in the
PR is installed during testing.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>