### PR TITLE
CART-89 build: Add a skip-pragma for CentOS 7 builds.

### DIFF
--- a/vars/sconsBuild.groovy
+++ b/vars/sconsBuild.groovy
@@ -11,7 +11,6 @@ def num_proc() {
     return sh(label: "Get number of processors online",
               script: "/usr/bin/getconf _NPROCESSORS_ONLN",
               returnStdout: true)
-          
 }
 
 def call(Map config = [:]) {
@@ -139,7 +138,8 @@ def call(Map config = [:]) {
     def scons_exe = 'scons'
     def scons_args = ''
     if (config['parallel_build'] && config['parallel_build'] == true) {
-        scons_args += '-j ' + num_proc()
+        String procs = num_proc()
+        scons_args += '-j ' + procs.trim()
     }
     def sconstruct = ''
     if (config['scons_exe']) {

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -205,6 +205,12 @@ boolean call(Map config = [:]) {
                    (docOnlyChange(target_branch) &&
                     prRepos('centos7') == '') ||
                    quickBuild()
+        case "Build on CentOS 7":
+            return paramsValue('CI_BUILD_PACKAGES_ONLY', false) ||
+                   skip_stage_pragma('build-centos7-gcc', 'false') ||
+                   (docOnlyChange(target_branch) &&
+                    prRepos('centos7') == '') ||
+                   quickBuild()
         case "Build on CentOS 8 release":
             return paramsValue('CI_BUILD_PACKAGES_ONLY', false) ||
                    skip_stage_pragma('build-centos8-gcc-release', 'true') ||


### PR DESCRIPTION
Add a Skip-build-centos7-gcc pragma, and enable parallel_build option
for docker builds.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
