### PR TITLE
DAOS-9090: remove ib2 tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -334,7 +334,7 @@ pipeline {
                                       [name: 'Fake CentOS 7 Functional Hardware Small stage',
                                        tag: 'hw,small'],
                                       [name: 'Fake CentOS 7 Functional Hardware Medium stage',
-                                       tag: 'hw,medium,ib2'],
+                                       tag: 'hw,medium'],
                                       [name: 'Fake CentOS 7 Functional Hardware Large stage',
                                        tag: 'hw,large']]
                             commits = [[tags: [[tag: "Test-tag", value: 'datamover']],

--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -178,7 +178,7 @@ def call(Map config = [:]) {
         result['pragma_suffix'] = '-hw-small'
       } else if (stage_name.contains('Medium')) {
         result['node_count'] = 5
-        cluster_size = 'hw,medium,ib2'
+        cluster_size = 'hw,medium'
         result['pragma_suffix'] = '-hw-medium'
       }
     }


### PR DESCRIPTION
All HW Medium clusters have dual IB, so the ib2 tag is not needed.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>