### PR TITLE
DAOS-9562 test: Support VMD clusters w/ non-Optane NVMes

### DIFF
--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -167,7 +167,7 @@ def call(Map config = [:]) {
     if (stage_name.contains('Hardware')) {
       cluster_size = 'hw,large'
       result['pragma_suffix'] = '-hw-large'
-      result['ftest_arg'] = '--nvme=auto:Optane'
+      result['ftest_arg'] = '--nvme=auto:-3DNAND'
       if (stage_name.contains('Small')) {
         result['node_count'] = 3
         cluster_size = 'hw,small'


### PR DESCRIPTION
To support newer clusters in CI update the default launch.py --nvme
argument for HW clusters.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>