### PR TITLE
DAOS-10535 tests: Install daos-*-tests-openmpi explicitly.

### DIFF
--- a/vars/getDAOSPackages.groovy
+++ b/vars/getDAOSPackages.groovy
@@ -26,7 +26,7 @@ String call(String distro, String next_version, String add_daos_pkgs) {
 
     String pkgs
     if (env.TEST_RPMS == 'true') {
-        pkgs = "daos{,-{client,tests,server,serialize}" + add_daos_pkgs + "}"
+        pkgs = "daos{,-{client{,-tests-openmpi},tests,server{,-tests-openmpi},serialize}" + add_daos_pkgs + "}"
     } else {
         pkgs = "daos{,-client}"
     }


### PR DESCRIPTION
The daos-{client,server}-tests-openmpi packages will no longer be
installed via daos-test requirements.  Explicitly install them for CI
testing.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>