### PR TITLE
DAOS-9979 ci: Enable regular weekly ucx testing

### DIFF
--- a/vars/functionalTest.groovy
+++ b/vars/functionalTest.groovy
@@ -62,11 +62,17 @@ def call(Map config = [:]) {
  
   Map stage_info = parseStageInfo(config)
 
+  // Install any additional rpms required for this stage
+  String stage_inst_rpms = config.get('inst_rpms', '')
+  if (stage_info['stage_rpms']) {
+    stage_inst_rpms = stage_info['stage_rpms'] + ' ' + stage_inst_rpms
+  }
+
   provisionNodes NODELIST: nodelist,
                  node_count: stage_info['node_count'],
                  distro: (stage_info['ci_target'] =~ /([a-z]+)(.*)/)[0][1] + stage_info['distro_version'],
                  inst_repos: config.get('inst_repos', ''),
-                 inst_rpms: config.get('inst_rpms', '')
+                 inst_rpms: stage_inst_rpms
 
   List stashes = []
   if (config['stashes']) {

--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -317,6 +317,12 @@ def call(Map config = [:]) {
     }
     result['test_tag'] = result['test_tag'].trim()
 
+    // Determine any additional rpms needed for this stage
+    result['stage_rpms'] = ''
+    if (ftest_arg_provider && ftest_arg_provider.contains('ucx')) {
+      result['stage_rpms'] = 'mercury-ucx'
+    }
+
     // if (stage_name.contains('Functional'))
   } else if (stage_name.contains('Storage')) {
     if (env.NODELIST) {


### PR DESCRIPTION
Enable installing the mercury-ucx RPM whenever the ucx provider is
specified for functional testing.  This will cover cases where the ucx
provider is specified through commit pragmas in any branch.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>