### PR TITLE
DAOS-9989 test: Fix Cannot invoke method startsWith() on null object

### DIFF
--- a/vars/testsInStage.groovy
+++ b/vars/testsInStage.groovy
@@ -12,7 +12,7 @@
 
 boolean call() {
     if (env.BRANCH_NAME.startsWith('weekly-testing') ||
-        env.CHANGE_TARGET.startsWith('weekly-testing')) {
+        (env.CHANGE_TARGET && env.CHANGE_TARGET.startsWith('weekly-testing'))) {
         /* This doesn't actually work on weekly-testing branches due to a lack
          * src/test/ftest/launch.py (and friends).  We could probably just
          * check that out from the branch we are testing against (i.e. master,


### PR DESCRIPTION
Daily PRs do not have CHANGE_TARGET defined, so verify the value is set
before checking its value.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>