### PR TITLE
DAOS-10847 pipeline: Reference EL8 for latest DAOS RPMs

### DIFF
--- a/vars/daosPackagesVersion.groovy
+++ b/vars/daosPackagesVersion.groovy
@@ -27,7 +27,7 @@ String normalize_distro(String distro) {
 String daos_latest_version(String next_version, String repo_type='stable') {
     String v = sh(label: "Get RPM packages version",
                   script: 'repoquery --repofrompath=daos,' + env.REPOSITORY_URL +
-                          env["DAOS_STACK_EL_7_" + repo_type.toUpperCase() + "_REPO"] +
+                          env["DAOS_STACK_EL_8_" + repo_type.toUpperCase() + "_REPO"] +
                         '''/ --repoid daos --qf %{version}-%{release} --whatprovides 'daos-tests(x86-64) < ''' +
                                      next_version + '''' |
                                  rpmdev-sort | tail -1''',


### PR DESCRIPTION
We have switched to EL8 for most builds, so reference EL8
instead of EL7 to determine the latest DAOS RPMs.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>