### PR TITLE
DAOS-9989 test: Enable provider-testing* branches

### DIFF
--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -191,14 +191,13 @@ set_local_repo() {
     local version
     version="$(lsb_release -sr)"
     version=${version%%.*}
-    if [ "$repo_server" = "artifactory" ] && [ -z "$(rpm_test_version)" ]; then
-        if [[ ${CHANGE_TARGET:-$BRANCH_NAME} != weekly-testing* ]] ||
-           [[ ${CHANGE_TARGET:-$BRANCH_NAME} != provider-testing* ]]; then
-            # Disable the daos repo so that the Jenkins job repo or a PR-repos*: repo is
-            # used for daos packages
-            dnf -y config-manager --disable \
-                daos-stack-daos-"${DISTRO_GENERIC}"-"$version"-x86_64-stable-local-artifactory
-        fi
+    if [ "$repo_server" = "artifactory" ] && [ -z "$(rpm_test_version)" ] &&
+       { [[ ${CHANGE_TARGET:-$BRANCH_NAME} != weekly-testing* ]] ||
+         [[ ${CHANGE_TARGET:-$BRANCH_NAME} != provider-testing* ]]; }; then
+         # Disable the daos repo so that the Jenkins job repo or a PR-repos*: repo is
+         # used for daos packages
+         dnf -y config-manager \
+            --disable daos-stack-daos-"${DISTRO_GENERIC}"-"$version"-x86_64-stable-local-artifactory
     fi
     dnf repolist
 }

--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -191,13 +191,14 @@ set_local_repo() {
     local version
     version="$(lsb_release -sr)"
     version=${version%%.*}
-    if [ "$repo_server" = "artifactory" ] &&
-       [ -z "$(rpm_test_version)" ] &&
-       [[ ${CHANGE_TARGET:-$BRANCH_NAME} != weekly-testing* ]]; then
-        # Disable the daos repo so that the Jenkins job repo or a PR-repos*: repo is
-        # used for daos packages
-        dnf -y config-manager \
-            --disable daos-stack-daos-"${DISTRO_GENERIC}"-"$version"-x86_64-stable-local-artifactory
+    if [ "$repo_server" = "artifactory" ] && [ -z "$(rpm_test_version)" ]; then
+        if [[ ${CHANGE_TARGET:-$BRANCH_NAME} != weekly-testing* ]] ||
+           [[ ${CHANGE_TARGET:-$BRANCH_NAME} != provider-testing* ]]; then
+            # Disable the daos repo so that the Jenkins job repo or a PR-repos*: repo is
+            # used for daos packages
+            dnf -y config-manager --disable \
+                daos-stack-daos-"${DISTRO_GENERIC}"-"$version"-x86_64-stable-local-artifactory
+        fi
     fi
     dnf repolist
 }

--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -194,9 +194,9 @@ set_local_repo() {
     if [ "$repo_server" = "artifactory" ] && [ -z "$(rpm_test_version)" ] &&
        { [[ ${CHANGE_TARGET:-$BRANCH_NAME} != weekly-testing* ]] ||
          [[ ${CHANGE_TARGET:-$BRANCH_NAME} != provider-testing* ]]; }; then
-         # Disable the daos repo so that the Jenkins job repo or a PR-repos*: repo is
-         # used for daos packages
-         dnf -y config-manager \
+        # Disable the daos repo so that the Jenkins job repo or a PR-repos*: repo is
+        # used for daos packages
+        dnf -y config-manager \
             --disable daos-stack-daos-"${DISTRO_GENERIC}"-"$version"-x86_64-stable-local-artifactory
     fi
     dnf repolist

--- a/vars/daosPackagesVersion.groovy
+++ b/vars/daosPackagesVersion.groovy
@@ -57,7 +57,8 @@ String call(String next_version) {
 String call(String distro, String next_version) {
     String target_branch = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
 
-    if (target_branch.startsWith("weekly-testing")) {
+    if (target_branch.startsWith("weekly-testing") ||
+        target_branch.startsWith("provider-testing")) {
         // weekly-test just wants the latest for the branch
         if (rpm_version_cache != "" && rpm_version_cache != "locked") {
             return rpm_version_cache + rpm_dist(distro)

--- a/vars/daosRepos.groovy
+++ b/vars/daosRepos.groovy
@@ -14,7 +14,8 @@ String daos_repo() {
 
     String target_branch = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
 
-    if (target_branch.startsWith("weekly-testing")) {
+    if (target_branch.startsWith("weekly-testing") ||
+        target_branch.startsWith("provider-testing")) {
         return ""
     }
 

--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -35,14 +35,8 @@
  *                             Default determined by this function below.
  */
 
-String get_build_params_tags(String param_key) {
+String get_build_params_tags() {
   // Get the tags defined by the build parameter entry for this stage
-  if (param_key == 'tcp' && params.TestTagTCP && params.TestTagTCP != '') {
-    return params.TestTagTCP
-  }
-  if (param_key == 'ucx' && params.TestTagUCX && params.TestTagUCX != '') {
-    return params.TestTagUCX
-  }
   if (params.TestTag && params.TestTag != '') {
     return params.TestTag
   }
@@ -204,7 +198,6 @@ def call(Map config = [:]) {
   String ftest_arg_nvme = ''
   String ftest_arg_repeat = ''
   String ftest_arg_provider = ''
-  String param_key = ''
   if (stage_name.contains('Functional')) {
     result['test'] = 'Functional'
     result['node_count'] = 9
@@ -223,15 +216,6 @@ def call(Map config = [:]) {
         cluster_size = 'hw,medium'
         result['pragma_suffix'] = '-hw-medium'
       }
-      if (stage_name.contains('TCP')) {
-        ftest_arg_provider = 'ofi+tcp'
-        param_key = 'tcp'
-        result['pragma_suffix'] += "-tcp"
-      } else if (stage_name.contains('UCX')) {
-        ftest_arg_provider = 'ucx+dc_x'
-        param_key = 'ucx'
-        result['pragma_suffix'] += "-ucx"
-      }
     }
     if (stage_name.contains('with Valgrind')) {
       result['pragma_suffix'] = '-valgrind'
@@ -243,7 +227,7 @@ def call(Map config = [:]) {
     String tag
     if (startedByUser()) {
       // Test tags defined by the build parameters override all other tags
-      tag = get_build_params_tags(param_key)
+      tag = get_build_params_tags()
     }
     if (!tag && startedByTimer()) {
       // Stage defined tags take precedence in timed builds
@@ -251,7 +235,7 @@ def call(Map config = [:]) {
       if (!tag) {
         // Otherwise use the default timed build tags
         tag = "pr daily_regression"
-        if (env.BRANCH_NAME.startsWith("weekly-testing") && !param_key) {
+        if (env.BRANCH_NAME.startsWith("weekly-testing")) {
           tag = "full_regression"
         }
       }

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -102,6 +102,7 @@ boolean skip_if_unstable() {
         cachedCommitPragma('Allow-unstable-test').toLowerCase() == 'true' ||
         env.BRANCH_NAME == 'master' ||
         env.BRANCH_NAME.startsWith("weekly-testing") ||
+        env.BRANCH_NAME.startsWith("provider-testing") ||
         env.BRANCH_NAME.startsWith("release/")) {
         return false
     }
@@ -316,6 +317,9 @@ boolean call(Map config = [:]) {
                    (env.BRANCH_NAME.startsWith('weekly-testing') &&
                     ! startedByTimer() &&
                     ! startedByUser()) ||
+                   (env.BRANCH_NAME.startsWith('provider-testing') &&
+                    ! startedByTimer() &&
+                    ! startedByUser()) ||
                    skip_if_unstable()
         case "Test on CentOS 7 [in] Vagrant":
             return skip_stage_pragma('vagrant-test', 'true') &&
@@ -405,6 +409,9 @@ boolean call(Map config = [:]) {
                    (env.BRANCH_NAME.startsWith('weekly-testing') &&
                     ! startedByTimer() &&
                     ! startedByUser()) ||
+                   (env.BRANCH_NAME.startsWith('provider-testing') &&
+                    ! startedByTimer() &&
+                    ! startedByUser()) ||
                    skip_if_unstable()
         case "Functional_Hardware_Small":
         case "Functional Hardware Small":
@@ -420,18 +427,6 @@ boolean call(Map config = [:]) {
         case "Bullseye Report on EL 8":
             return env.BULLSEYE == null ||
                    skip_stage_pragma('bullseye', 'true')
-        case 'Functional Hardware Small TCP':
-            return skip_ftest_hw('small-tcp', target_branch)
-        case 'Functional Hardware Medium TCP':
-            return skip_ftest_hw('medium-tcp', target_branch)
-        case 'Functional Hardware Large TCP':
-            return skip_ftest_hw('large-tcp', target_branch)
-        case 'Functional Hardware Small UCX':
-            return skip_ftest_hw('small-ucx', target_branch)
-        case 'Functional Hardware Medium UCX':
-            return skip_ftest_hw('medium-ucx', target_branch)
-        case 'Functional Hardware Large UCX':
-            return skip_ftest_hw('large-ucx', target_branch)
         default:
             println("Don't know how to skip stage \"${env.STAGE_NAME}\", not skipping")
     }

--- a/vars/testsInStage.groovy
+++ b/vars/testsInStage.groovy
@@ -12,7 +12,9 @@
 
 boolean call() {
     if (env.BRANCH_NAME.startsWith('weekly-testing') ||
-        (env.CHANGE_TARGET && env.CHANGE_TARGET.startsWith('weekly-testing'))) {
+        env.BRANCH_NAME.startsWith('provider-testing') ||
+        (env.CHANGE_TARGET && env.CHANGE_TARGET.startsWith('weekly-testing')) ||
+        (env.CHANGE_TARGET && env.CHANGE_TARGET.startsWith('provider-testing'))) {
         /* This doesn't actually work on weekly-testing branches due to a lack
          * src/test/ftest/launch.py (and friends).  We could probably just
          * check that out from the branch we are testing against (i.e. master,


### PR DESCRIPTION
Enable weekly tcp/ucx testing in new provider-testing* branches.  Remove
references to the no longer used Functional Hardware * TCP/UCX test
stages.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>