### PR TITLE
Revert "DAOS-623 build: Update docker cachebust to be weekly. (#292)"

### DIFF
--- a/ci/provisioning/post_provision_config.sh
+++ b/ci/provisioning/post_provision_config.sh
@@ -26,6 +26,9 @@ DSA_REPO_var="DAOS_STACK_${DISTRO}_APPSTREAM_REPO"
 
 retry_cmd 300 clush -B -S -l root -w "$NODESTRING" -c ci_key* --dest=/tmp/
 
+# shellcheck disable=SC2001
+sanitized_commit_message="$(echo "$COMMIT_MESSAGE" | sed -e 's/\(["\$]\)/\\\1/g')"
+
 if ! retry_cmd 2400 clush -B -S -l root -w "$NODESTRING" \
            "export PS4='$PS4'
            MY_UID=$(id -u)
@@ -44,13 +47,13 @@ if ! retry_cmd 2400 clush -B -S -l root -w "$NODESTRING" \
            BUILD_URL=\"${BUILD_URL}\"
            STAGE_NAME=\"${STAGE_NAME}\"
            OPERATIONS_EMAIL=\"${OPERATIONS_EMAIL}\"
-           COMMIT_MESSAGE=\"${COMMIT_MESSAGE-}\"
+           COMMIT_MESSAGE=\"$sanitized_commit_message\"
            REPO_FILE_URL=\"$REPO_FILE_URL\"
            ARTIFACTORY_URL=\"${ARTIFACTORY_URL:-}\"
-           CI_RPM_TEST_VERSION=\"${CI_RPM_TEST_VERSION:-}\"
-           CI_PR_REPOS=\"${CI_PR_REPOS:-}\"
            BRANCH_NAME=\"${BRANCH_NAME:-}\"
            CHANGE_TARGET=\"${CHANGE_TARGET:-}\"
+           CI_RPM_TEST_VERSION=\"${CI_RPM_TEST_VERSION:-}\"
+           CI_PR_REPOS=\"${CI_PR_REPOS:-}\"
            $(cat ci/stacktrace.sh)
            $(cat ci/junit.sh)
            $(cat ci/provisioning/post_provision_config_common_functions.sh)

--- a/vars/dockerBuildArgs.groovy
+++ b/vars/dockerBuildArgs.groovy
@@ -114,7 +114,10 @@ String call(Map config = [:]) {
                      " --build-arg JENKINS_URL=$env.JENKINS_URL"
     if (cachebust) {
       Calendar current_time = Calendar.getInstance()
-      ret_str += " --build-arg CACHEBUST=" + current_time.get(Calendar.WEEK_OF_YEAR)
+      // *NEVER* redefine CACHEBUST to some other value.  If you think something
+      // in a Dockerfile needs doing less frequently than *always* consider either
+      // CB0 (below) or define a new cache-bust interval
+      ret_str += " --build-arg CACHEBUST=${currentBuild.startTimeInMillis}"
       ret_str += " --build-arg CB0=" + current_time.get(Calendar.WEEK_OF_YEAR)
     }
 


### PR DESCRIPTION
This reverts commit 62bc371d9c568cab1aaa4dadb3e755ad993c1bce.

CACHEBUST was always intended to be an absolute cache buster.  It was
not meant to represent tasks that were subsequently decided should be
done weekly instead of done always.  CB0 is in fact exactly that -- a
weekly cache buster and should have been used where CACHEBUST was
repurposed to be weekly.

There are, and always will be tasks which we want to happen on every
Docker build.  These are forced with CACHEBUST.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>