### PR TITLE
SRE-519 Build: Fix junit failure lookup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,6 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value='pipeline-lib@my_branch_name') _
-@Library(value='pipeline-lib@sre-519') _
 
 String test_branch(String target) {
     return 'ci-' + JOB_NAME.replaceAll('/', '-') +

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value='pipeline-lib@my_branch_name') _
+@Library(value='pipeline-lib@sre-519') _
 
 String test_branch(String target) {
     return 'ci-' + JOB_NAME.replaceAll('/', '-') +
@@ -68,7 +69,7 @@ pipeline {
                     steps {
                         runTest script: '''set -ex
                                            rm -f *.xml
-                                           echo "<failure bla bla bla/>" > \
+                                           echo "<failure> bla bla bla</failure>" > \
                                              pipeline-test-failure.xml''',
                             junit_files: '*.xml non-exist*.xml',
                             failure_artifacts: env.STAGE_NAME

--- a/vars/checkJunitFiles.groovy
+++ b/vars/checkJunitFiles.groovy
@@ -52,7 +52,7 @@ String call(Map config = [:]) {
         status = 'FAILURE'
         println 'Found at least one error in the Junit files.'
     } else if (sh(label: 'Check junit xml files for failures',
-                  script: 'grep "<failure " ' + junit_xml,
+                  script: 'grep -E "<failure( |>)" ' + junit_xml,
                   returnStatus: true) == 0) {
         status = 'UNSTABLE'
         println 'Found at least one failure in the junit files.'


### PR DESCRIPTION
Junit failures can be "<failure " or "<failure>".

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>