### PR TITLE
DAOS-12023 ci: Add HW Medium Provider stages

### DIFF
--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -523,6 +523,12 @@ boolean call(Map config = [:]) {
         case 'Functional_Hardware_Medium':
         case 'Functional Hardware Medium':
             return skip_ftest_hw('medium', target_branch)
+        case 'Functional_Hardware_Medium_Verbs_Provider':
+        case 'Functional Hardware Medium Verbs Provider':
+            return skip_ftest_hw('medium-verbs-provider', target_branch)
+        case 'Functional_Hardware_Medium_UCX_Provider':
+        case 'Functional Hardware Medium UCX Provider':
+            return skip_ftest_hw('medium-ucx-provider', target_branch)
         case 'Functional_Hardware_Large':
         case 'Functional Hardware Large':
             return skip_ftest_hw('large', target_branch)


### PR DESCRIPTION
Adding support for the new Functional Hardware Medium <name> Provider stages.  These new functional test stages require a fixed test provider setting and will run any appropraitely sized test with the 'provider' tag.

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>