### PR TITLE
DAOS-12064 test: Remove HW Small stage from pipeline-lib testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -486,8 +486,7 @@ pipeline {
                                                booleanParam(name: 'CI_FUNCTIONAL_leap15_TEST', value: true),
                                                booleanParam(name: 'CI_SCAN_RPMS_el7_TEST', value: true),
                                                booleanParam(name: 'CI_RPMS_el7_TEST', value: true),
-                                               booleanParam(name: 'CI_small_TEST', value: true),
-                                               booleanParam(name: 'CI_medium_TEST', value: false),
+                                               booleanParam(name: 'CI_medium_TEST', value: true),
                                                booleanParam(name: 'CI_large_TEST', value: false)
                                               ]
                         } //steps

--- a/vars/packageBuildingPipelineDAOSTest.groovy
+++ b/vars/packageBuildingPipelineDAOSTest.groovy
@@ -755,8 +755,6 @@ void call(Map pipeline_args) {
                                                    booleanParam(name: 'CI_SCAN_RPMS_el7_TEST', value: false),
                                                    booleanParam(name: 'CI_RPMS_el7_TEST',
                                                                 value: 'centos7' in distros),
-                                                   booleanParam(name: 'CI_small_TEST',
-                                                                value: 'el8' in distros),
                                                    booleanParam(name: 'CI_medium_TEST', value: false),
                                                    booleanParam(name: 'CI_large_TEST', value: false),
                                                    string(name: 'CI_PR_REPOS',

--- a/vars/packageBuildingPipelineDAOSTest.groovy
+++ b/vars/packageBuildingPipelineDAOSTest.groovy
@@ -755,7 +755,8 @@ void call(Map pipeline_args) {
                                                    booleanParam(name: 'CI_SCAN_RPMS_el7_TEST', value: false),
                                                    booleanParam(name: 'CI_RPMS_el7_TEST',
                                                                 value: 'centos7' in distros),
-                                                   booleanParam(name: 'CI_medium_TEST', value: false),
+                                                   booleanParam(name: 'CI_medium_TEST',
+                                                                value: 'el8' in distros),
                                                    booleanParam(name: 'CI_large_TEST', value: false),
                                                    string(name: 'CI_PR_REPOS',
                                                           value: env.JOB_NAME.split('/')[1] + '@' +


### PR DESCRIPTION
Update pipeline-lib dependency building stages to remove the no longer used Functional Hardware Small stage.

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>