### PR TITLE
DAOS-11624 test: Adding support for the Test-storage-tier pragma

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -377,7 +377,7 @@ pipeline {
                                         cmp = cmp.replace('@stages.tag@', stage.tag)
                                         // Useful for debugging since Jenkins'
                                         // assert() is pretty lame
-                                        // println('assert(' + parseStageInfo()['test_tag'] + " == ${cmp})")
+                                        println('assert(' + parseStageInfo()['test_tag'] + " == ${cmp})")
                                         assert(parseStageInfo()['test_tag'] == cmp)
                                     }
                                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -292,7 +292,6 @@ pipeline {
                             stages = ['Functional on Leap 15',
                                       'Functional on CentOS 7',
                                       'Functional on EL 8',
-                                      'Functional Hardware Small',
                                       'Functional Hardware Medium',
                                       'Functional Hardware Large']
                             commits = [[pragmas: ['Skip-func-test-leap15: false'],
@@ -301,7 +300,7 @@ pipeline {
                                        [pragmas: [''],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
                                         skips: [isPr(), isPr(), false, !isPr(), !isPr(), !isPr()]],
-                                       [pragmas: ['Skip-func-hw-test-small: true'],
+                                       [pragmas: ['Skip-func-hw-test-medium: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
                                         skips: [isPr(), isPr(), false, true, !isPr(), !isPr()]]]
                             commits.each { commit ->
@@ -336,11 +335,11 @@ pipeline {
                         // lots more test cases could be cooked up, to be sure
                         script {
                             stages = [[name: 'Fake CentOS 7 Functional stage',
-                                       tag: '-hw'],
-                                      [name: 'Fake CentOS 7 Functional Hardware Small stage',
-                                       tag: 'hw,small'],
+                                       tag: '-hw',],
                                       [name: 'Fake CentOS 7 Functional Hardware Medium stage',
-                                       tag: 'hw,medium'],
+                                       tag: 'hw,medium,-provider'],
+                                      [name: 'Fake CentOS 7 Functional Hardware Medium Provider stage',
+                                       tag: 'hw,medium,provider'],
                                       [name: 'Fake CentOS 7 Functional Hardware Large stage',
                                        tag: 'hw,large']]
                             commits = [[tags: [[tag: 'Test-tag', value: 'datamover']],
@@ -377,7 +376,7 @@ pipeline {
                                         cmp = cmp.replace('@stages.tag@', stage.tag)
                                         // Useful for debugging since Jenkins'
                                         // assert() is pretty lame
-                                        println('assert(' + parseStageInfo()['test_tag'] + " == ${cmp})")
+                                        // println('assert(' + parseStageInfo()['test_tag'] + " == ${cmp})")
                                         assert(parseStageInfo()['test_tag'] == cmp)
                                     }
                                 }

--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -208,6 +208,7 @@ void call(Map config = [:]) {
   String ftest_arg_nvme = ''
   String ftest_arg_repeat = ''
   String ftest_arg_provider = ''
+  String ftest_arg_storage_tier = ''
   if (stage_name.contains('Functional')) {
     result['test'] = 'Functional'
     result['node_count'] = 9
@@ -300,6 +301,10 @@ void call(Map config = [:]) {
         'Test-provider' + result['pragma_suffix'], cachedCommitPragma('Test-provider', null))
     }
 
+    // Get the ftest --storage_tier argument from either the build parameters or commit pragmas
+    ftest_arg_storage_tier = params.TestStorageTier ?: cachedCommitPragma(
+      'Test-storage-tier' + result['pragma_suffix'], cachedCommitPragma('Test-storage-tier', null))
+
     // Assemble the ftest args
     result['ftest_arg'] = ''
     if (ftest_arg_nvme) {
@@ -310,6 +315,9 @@ void call(Map config = [:]) {
     }
     if (ftest_arg_provider) {
       result['ftest_arg'] += ' --provider=' +  ftest_arg_provider
+    }
+    if (ftest_arg_storage_tier) {
+      result['ftest_arg'] += ' --storage_tier=' +  ftest_arg_storage_tier
     }
     if (result['ftest_tag']) {
       result['ftest_tag'] = result['ftest_tag'].trim()

--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -70,11 +70,13 @@ String get_commit_pragma_tags(String pragma_suffix) {
   return pragma_tag
 }
 
-String get_param_or_pragma(param, pragma, arg, predefined) {
-    String res = params.$param ?: cachedCommitPragma(
-      pragma + result['pragma_suffix'], cachedCommitPragma(pragma, predefined))
+String get_param_or_pragma(param, pragma, pragma_suffix, launch_arg, predefined) {
+  // Get the launch.py argument value from either the build parameter, stage-specific commit
+  // pragma, general commit pragma, or predefined value
+  String res = params.$param ?: cachedCommitPragma(
+    pragma + pragma_suffix, cachedCommitPragma(pragma, predefined))
 
-    return res ? ' ' + arg + '= ' + res : ''
+  return res ? ' ' + launch_arg + '= ' + res : ''
 }
 
 /* groovylint-disable-next-line MethodSize */
@@ -292,18 +294,20 @@ void call(Map config = [:]) {
 
     // Assemble the ftest args from either the build parameters or commit pragmas
     result['ftest_arg'] = ''
-    result['ftest_arg'] += get_param_or_pragma('TestNvme', 'Test-nvme', '--nvme', ftest_arg_nvme)
-    result['ftest_arg'] += get_param_or_pragma('TestRepeat', 'Test-repeat', '--repeat', null)
+    result['ftest_arg'] += get_param_or_pragma(
+      'TestNvme', 'Test-nvme', result['pragma_suffix'],'--nvme', ftest_arg_nvme)
+    result['ftest_arg'] += get_param_or_pragma(
+      'TestRepeat', 'Test-repeat', result['pragma_suffix'], '--repeat', null)
     if (ftest_arg_provider) {
       // Use the specific provider defined by the stage
       result['ftest_arg'] += ' --provider=' +  ftest_arg_provider
     } else {
       // Only use a build parameter or commit pragma provider for non-provider-specific stages
       result['ftest_arg'] += get_param_or_pragma(
-        'TestProvider', 'Test-provider', '--provider', null)
+        'TestProvider', 'Test-provider', result['pragma_suffix'], '--provider', null)
     }
     result['ftest_arg'] += get_param_or_pragma(
-      'TestStorageTier', 'Test-storage-tier', '--storage_tier', null)
+      'TestStorageTier', 'Test-storage-tier', result['pragma_suffix'], '--storage_tier', null)
     if (result['ftest_tag']) {
       result['ftest_tag'] = result['ftest_tag'].trim()
     }


### PR DESCRIPTION
Adding support for passing the Test-storage-tier build parameter or commit pragma to launch.py via its --storage_tier argument.

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>