### PR TITLE
DAOS-12021 test: Add support for HW Medium TCP Provider stage

### DIFF
--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -235,6 +235,10 @@ void call(Map config = [:]) {
             result['pragma_suffix'] += '-ucx-provider'
             ftest_arg_provider = 'ucx+dc_x'
           }
+          else if (stage_name.contains('TCP')) {
+            result['pragma_suffix'] += '-tcp-provider'
+            ftest_arg_provider = 'ofi+tcp'
+          }
         }
       } else if (stage_name.contains('Hardware 24')) {
         result['node_count'] = 24

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -529,6 +529,8 @@ boolean call(Map config = [:]) {
         case 'Functional_Hardware_Medium':
         case 'Functional Hardware Medium':
             return skip_ftest_hw('medium', target_branch)
+        case 'Functional Hardware Medium TCP Provider':
+            return skip_ftest_hw('medium-tcp-provider', target_branch)
         case 'Functional Hardware Medium Verbs Provider':
             return skip_ftest_hw('medium-verbs-provider', target_branch)
         case 'Functional Hardware Medium UCX Provider':


### PR DESCRIPTION
Add support for the Functional Hardware Medium TCP Provider stage in order to run any 'provider' tagged tests in the tcp provider branches.

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>