### PR TITLE
DAOS-12562 test: Remove 'Functional Hardware Medium UCX Provider' stage for PRs

### DIFF
--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -167,7 +167,9 @@ boolean skip_ftest_hw(String size, String target_branch) {
             !(startedByTimer() || startedByUser())) ||
            cachedCommitPragma('Run-daily-stages') == 'true' ||
            (docOnlyChange(target_branch) &&
-            prRepos(hwDistroTarget(size)) == '')
+            prRepos(hwDistroTarget(size)) == '') ||
+           /* groovylint-disable-next-line UnnecessaryGetter */
+           (isPr() && size == 'medium-ucx-provider')
 }
 
 boolean skip_if_unstable() {


### PR DESCRIPTION
Remove ‘Functional Hardware Medium UCX Provider' stage for PRs but keep it for daily runs.
Modifyng 'vars/skipStage.groovy' in pipeline-lib.

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>