### PR TITLE
DAOS-12441 test: Publish RPMs from testbuild branches

### DIFF
--- a/vars/publishToRepository.groovy
+++ b/vars/publishToRepository.groovy
@@ -48,6 +48,7 @@ def call(Map config = [:]) {
     } else {
         // Only publish on known landing (i.e. release) branches (unless testing)
         if (!env.BRANCH_NAME.startsWith("release/") &&
+            !env.BRANCH_NAME.startsWith("testbuild/") &&
             env.BRANCH_NAME != 'master' &&
             !config['test']) {
                 return


### PR DESCRIPTION
Include publishing RPMs to artifactory from testbuild branches.