### PR TITLE
DAOS-623 test: Fix link to Jenkins test results.

### DIFF
--- a/vars/stepResult.groovy
+++ b/vars/stepResult.groovy
@@ -48,7 +48,7 @@ Void call(Map config= [:]) {
   if (config['junit_files'] && config['result'] != 'FAILURE') {
     log_url = env.JOB_URL - ~/job\/[^\/]*\/$/ +
               "/view/change-requests/job/${env.BRANCH_NAME}/" +
-              "${env.BUILD_ID}/testReport/(root)/"
+              "${env.BUILD_ID}/testReport/"
   } else {
     def h = new doGetHttpRequest()
     resp = h.doGetHttpRequest(env.JOB_URL - ~/\/job\/[^\/]*\/$/ +


### PR DESCRIPTION
Test results have a optional class name  which defaults
to (root) however the Github comments on test failures link
to this default class.  This means that for tests which define
a class but fail the link can either be invalid or point to
other, un-related tests which might not have failed.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
