### PR TITLE
DAOS-623 pmdk: mimic how PMDK's CI prepares docker's tmpfs for tests

### DIFF
--- a/vars/packageBuildingPipeline.groovy
+++ b/vars/packageBuildingPipeline.groovy
@@ -302,7 +302,8 @@ void call(Map pipeline_args) {
                                 label 'docker_runner'
                                 args '--group-add mock' +
                                      ' --cap-add=SYS_ADMIN' +
-                                     ' --privileged=true'
+                                     ' --privileged=true' +
+                                     ' --tmpfs /tmp:rw,relatime,suid,dev,exec,size=6G'
                                 additionalBuildArgs dockerBuildArgs()
                             }
                         }
@@ -381,7 +382,8 @@ void call(Map pipeline_args) {
                                 label 'docker_runner'
                                 args '--group-add mock' +
                                      ' --cap-add=SYS_ADMIN' +
-                                     ' --privileged=true'
+                                     ' --privileged=true' +
+                                     ' --tmpfs /tmp:rw,relatime,suid,dev,exec,size=6G'
                                 additionalBuildArgs dockerBuildArgs()
                             }
                         }
@@ -459,7 +461,8 @@ void call(Map pipeline_args) {
                                 label 'docker_runner'
                                 args '--group-add mock' +
                                      ' --cap-add=SYS_ADMIN' +
-                                     ' --privileged=true'
+                                     ' --privileged=true' +
+                                     ' --tmpfs /tmp:rw,relatime,suid,dev,exec,size=6G'
                                 additionalBuildArgs dockerBuildArgs()
                             }
                         }


### PR DESCRIPTION
Required by daos-stack/pmdk and especially by daos-stack/pmdk#26. Tests fail currently because flock(2) allows locking file which is already locked exclusively.

The introduced tmpfs is intended to closely resemble how tmpfs works without docker involved.

Ref: pmem/pmdk#4467
Ref: PMDK-72