### PR TITLE
Add daosPackagesVersion() tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,6 +115,15 @@ pipeline {
         }
         stage('Test') {
             parallel {
+                stage('daosLatestVersion() tests') {
+                    steps {
+                        script {
+                            assert(daosLatestVersion('master', 'el8').startsWith('2.5.'))
+                            assert(daosLatestVersion('release/2.4', 'el8').startsWith('2.3.'))
+                            assert(daosLatestVersion('release/2.2', 'el8').startsWith('2.2.'))
+                        }
+                    }
+                }
                 stage('grep JUnit results tests failure case') {
                     agent {
                         docker {

--- a/vars/packageBuildingPipelineDAOSTest.groovy
+++ b/vars/packageBuildingPipelineDAOSTest.groovy
@@ -819,7 +819,7 @@ void call(Map pipeline_args) {
                                                           value: ('load_mpi test_core_files ' +
                                                                    pipeline_args.get('test-tag', '')).trim()),
                                                    string(name: 'CI_RPM_TEST_VERSION',
-                                                          value: daosLatestVersion(env.TEST_BRANCH)),
+                                                          value: daosLatestVersion(env.TEST_BRANCH), 'el8'),
                                                    string(name: 'CI_PROVISIONING_POOL', value: 'default'),
                                                    string(name: 'CI_BUILD_DESCRIPTION',
                                                           value: 'Dependency Validation Build Test'),

--- a/vars/packageBuildingPipelineDAOSTest.groovy
+++ b/vars/packageBuildingPipelineDAOSTest.groovy
@@ -819,7 +819,7 @@ void call(Map pipeline_args) {
                                                           value: ('load_mpi test_core_files ' +
                                                                    pipeline_args.get('test-tag', '')).trim()),
                                                    string(name: 'CI_RPM_TEST_VERSION',
-                                                          value: daosLatestVersion(env.TEST_BRANCH), 'el8'),
+                                                          value: daosLatestVersion(env.TEST_BRANCH, 'el8')),
                                                    string(name: 'CI_PROVISIONING_POOL', value: 'default'),
                                                    string(name: 'CI_BUILD_DESCRIPTION',
                                                           value: 'Dependency Validation Build Test'),

--- a/vars/rpmDistValue.groovy
+++ b/vars/rpmDistValue.groovy
@@ -1,0 +1,30 @@
+// vars/rpmDistValue.groovy
+
+/**
+ * rpmDistValue.groovy
+ *
+ * rpmDistValue variable
+ */
+
+/**
+ * Method to return the %{dist} value of an OS
+ */
+
+String call(String distro) {
+    if (distro.startsWith('el7') || distro.startsWith('centos7')) {
+        return '.el7'
+    } else if (distro.startsWith('el8') || distro.startsWith('centos8') ||
+               distro.startsWith('rocky8') || distro.startsWith('almalinux8') ||
+               distro.startsWith('rhel8')) {
+        return '.el8'
+    } else if (distro.startsWith('el9') || distro.startsWith('centos9') ||
+               distro.startsWith('rocky9') || distro.startsWith('almalinux9') ||
+               distro.startsWith('rhel9')) {
+        return '.el9'
+    } else if (distro.startsWith('leap15')) {
+        return '.suse.lp' + parseStageInfo()['distro_version'].replaceAll('\\.', '')
+    }
+    error("Don't know what the RPM %{dist} is for ${distro}")
+    return
+}
+

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -142,7 +142,7 @@ boolean skip_ftest(String distro, String target_branch) {
            (docOnlyChange(target_branch) &&
             prRepos(distro) == '') ||
            /* groovylint-disable-next-line UnnecessaryGetter */
-           (isPr() && !(distro in ['el8', 'el9']))
+           (isPr() && !(distro in ['el8']))
 }
 
 boolean skip_ftest_valgrind(String distro, String target_branch) {

--- a/vars/testBranchRE.groovy
+++ b/vars/testBranchRE.groovy
@@ -9,4 +9,3 @@ String call() {
     // Also support older branch names not ending in '-testing'
     return(/^[-\w.]+-testing(?:-(?:tcp|ucx))?(?:-2\.2)?$/)
 }
-


### PR DESCRIPTION
Add daosLatestVersion() tests.

Use el8 as the distro to find latest packages in
packageBuildingPipelineDAOSTest().

Add rpmDistValue() variable.

Disable EL9 running on PRs by default.