### PR TITLE
DAOS-13934 test: Support passing launch.py args per stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,6 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value='pipeline-lib@my_branch_name') _
-@Library(value='pipeline-lib@pahender/DAOS-13934') _
 
 /* groovylint-disable-next-line CompileStatic */
 job_status_internal = [:]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -456,10 +456,10 @@ pipeline {
                                        [pragmas: ['Skip-build-el8-rpm: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
                                         skips: [isPr(), isPr(), true, isPr(), true, true, true, true]],
-                                       [pragmas: ['Skip-build-el9-rpm: true\nSkip-func-test-el9: false'],
+                                       [pragmas: ['Skip-build-el9-rpm: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
                                         skips: [isPr(), isPr(), false, true, !isPr(), !isPr(), isPr(), !isPr()]],
-                                       [pragmas: ['Skip-build-leap15-rpm: true\nSkip-func-test-leap15: false'],
+                                       [pragmas: ['Skip-build-leap15-rpm: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
                                         skips: [true, isPr(), false, isPr(), !isPr(), !isPr(), isPr(), !isPr()]]]
                             errors = 0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value='pipeline-lib@my_branch_name') _
-@Library(value='pipeline-lib@pahender/DAOS-13536-simple') _
+@Library(value='pipeline-lib@pahender/DAOS-13934') _
 
 /* groovylint-disable-next-line CompileStatic */
 job_status_internal = [:]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value='pipeline-lib@my_branch_name') _
+@Library(value='pipeline-lib@pahender/DAOS-13536-simple') _
 
 /* groovylint-disable-next-line CompileStatic */
 job_status_internal = [:]
@@ -399,64 +400,68 @@ pipeline {
                             stages = ['Functional on Leap 15',
                                       'Functional on CentOS 7',
                                       'Functional on EL 8',
+                                      'Functional on EL 9',
                                       'Functional Hardware Medium',
                                       'Functional Hardware Medium Verbs Provider',
                                       'Functional Hardware Medium UCX Provider',
                                       'Functional Hardware Large']
                             commits = [[pragmas: [''],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), false, !isPr(), !isPr(), isPr(), !isPr()]],
+                                        skips: [isPr(), isPr(), false, isPr(), !isPr(), !isPr(), isPr(), !isPr()]],
                                        [pragmas: ['Skip-test: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [true, true, true, true, true, true, true]],
+                                        skips: [true, true, true, true, true, true, true, true]],
                                        [pragmas: ['Skip-func-test: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [true, true, true, true, true, true, true]],
+                                        skips: [true, true, true, true, true, true, true, true]],
                                        [pragmas: ['Skip-func-test-vm: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [true, true, true, !isPr(), !isPr(), isPr(), !isPr()]],
+                                        skips: [true, true, true, true, !isPr(), !isPr(), isPr(), !isPr()]],
                                        [pragmas: ['Skip-func-test-vm-all: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [true, true, true, !isPr(), !isPr(), isPr(), !isPr()]],
+                                        skips: [true, true, true, true, !isPr(), !isPr(), isPr(), !isPr()]],
                                        [pragmas: ['Skip-func-test-el8: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), true, !isPr(), !isPr(), isPr(), !isPr()]],
+                                        skips: [isPr(), isPr(), true, isPr(), !isPr(), !isPr(), isPr(), !isPr()]],
                                        [pragmas: ['Skip-func-test-leap15: false'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [false, isPr(), false, !isPr(), !isPr(), true, !isPr()]],
+                                        skips: [false, isPr(), false, isPr(), !isPr(), !isPr(), true, !isPr()]],
                                        [pragmas: ['Skip-func-test: true\nSkip-func-test-el8: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [true, true, true, true, true, true, true]],
-                                       [pragmas: ['Skip-func-test-leap15: false\nSkip-func-test-el7: false'],
+                                        skips: [true, true, true, true, true, true, true, true]],
+                                       [pragmas: ['Skip-func-test-leap15: false\nSkip-func-test-el7: false\nSkip-func-test-el9: false'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [false, false, false, !isPr(), !isPr(), true, !isPr()]],
+                                        skips: [false, false, false, false, !isPr(), !isPr(), true, !isPr()]],
                                        [pragmas: ['Skip-func-test-hw: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), false, true, true, true, true]],
+                                        skips: [isPr(), isPr(), false, isPr(), true, true, true, true]],
                                        [pragmas: ['Skip-func-test-hw-medium: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), false, true, !isPr(), isPr(), !isPr()]],
+                                        skips: [isPr(), isPr(), false, isPr(), true, !isPr(), isPr(), !isPr()]],
                                        [pragmas: ['Skip-func-test-hw-medium-ucx-provider: false'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), false, !isPr(), !isPr(), !isPr(), !isPr()]],
+                                        skips: [isPr(), isPr(), false, isPr(), !isPr(), !isPr(), !isPr(), !isPr()]],
                                        [pragmas: ['Skip-func-hw-test: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), false, true, true, true, true]],
+                                        skips: [isPr(), isPr(), false, isPr(), true, true, true, true]],
                                        [pragmas: ['Skip-func-hw-test-medium: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), false, true, !isPr(), isPr(), !isPr()]],
+                                        skips: [isPr(), isPr(), false, isPr(), true, !isPr(), isPr(), !isPr()]],
                                        [pragmas: ['Skip-func-hw-test-medium-ucx-provider: false'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), false, !isPr(), !isPr(), !isPr(), !isPr()]],
+                                        skips: [isPr(), isPr(), false, isPr(), !isPr(), !isPr(), !isPr(), !isPr()]],
                                        [pragmas: ['Run-daily-stages: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), false, false, false, false, false]],
+                                        skips: [isPr(), isPr(), false, isPr(), false, false, false, false]],
                                        [pragmas: ['Skip-build-el8-rpm: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), true, true, true, true, true]],
-                                       [pragmas: ['Skip-build-leap15-rpm: true'],
+                                        skips: [isPr(), isPr(), true, isPr(), true, true, true, true]],
+                                       [pragmas: ['Skip-build-el9-rpm: true\nSkip-func-test-el9: false'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [true, isPr(), false, !isPr(), !isPr(), isPr(), !isPr()]]]
+                                        skips: [isPr(), isPr(), false, true, !isPr(), !isPr(), isPr(), !isPr()]],
+                                       [pragmas: ['Skip-build-leap15-rpm: true\nSkip-func-test-leap15: false'],
+                                        /* groovylint-disable-next-line UnnecessaryGetter */
+                                        skips: [true, isPr(), false, isPr(), !isPr(), !isPr(), isPr(), !isPr()]]]
                             errors = 0
                             commits.each { commit ->
                                 cm = 'Test commit\n\n'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -420,48 +420,63 @@ pipeline {
                                        [pragmas: ['Skip-func-test-vm-all: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
                                         skips: [true, true, true, true, !isPr(), !isPr(), isPr(), !isPr()]],
-                                       [pragmas: ['Skip-func-test-el8: true'],
+                                       [pragmas: ['Skip-func-test-leap15: true\n' +
+                                                  'Skip-func-test-el7: true\n' +
+                                                  'Skip-func-test-el8: true\n' +
+                                                  'Skip-func-test-el9: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), true, isPr(), !isPr(), !isPr(), isPr(), !isPr()]],
-                                       [pragmas: ['Skip-func-test-leap15: false'],
-                                        /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [false, isPr(), false, isPr(), !isPr(), !isPr(), true, !isPr()]],
-                                       [pragmas: ['Skip-func-test: true\nSkip-func-test-el8: true'],
-                                        /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [true, true, true, true, true, true, true, true]],
-                                       [pragmas: ['Skip-func-test-leap15: false\nSkip-func-test-el7: false\nSkip-func-test-el9: false'],
+                                        skips: [true, true, true, true, !isPr(), !isPr(), true, !isPr()]],
+                                       [pragmas: ['Skip-func-test-leap15: false\n' +
+                                                  'Skip-func-test-el7: false\n' +
+                                                  'Skip-func-test-el8: false\n' +
+                                                  'Skip-func-test-el9: false'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
                                         skips: [false, false, false, false, !isPr(), !isPr(), true, !isPr()]],
                                        [pragmas: ['Skip-func-test-hw: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
                                         skips: [isPr(), isPr(), false, isPr(), true, true, true, true]],
-                                       [pragmas: ['Skip-func-test-hw-medium: true'],
+                                       [pragmas: ['Skip-func-test-hw-medium: true\n' +
+                                                  'Skip-func-test-hw-medium-verbs-provider: true\n' +
+                                                  'Skip-func-test-hw-medium-ucx-provider: true\n' +
+                                                  'Skip-func-test-hw-large: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), false, isPr(), true, !isPr(), isPr(), !isPr()]],
-                                       [pragmas: ['Skip-func-test-hw-medium-ucx-provider: false'],
+                                        skips: [isPr(), isPr(), false, isPr(), true, true, true, true]],
+                                       [pragmas: ['Skip-func-test-hw-medium: false\n' +
+                                                  'Skip-func-test-hw-medium-verbs-provider: false\n' +
+                                                  'Skip-func-test-hw-medium-ucx-provider: false\n' +
+                                                  'Skip-func-test-hw-large: false'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), false, isPr(), !isPr(), !isPr(), !isPr(), !isPr()]],
+                                        skips: [isPr(), isPr(), false, isPr(), false, false, false, false]],
                                        [pragmas: ['Skip-func-hw-test: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
                                         skips: [isPr(), isPr(), false, isPr(), true, true, true, true]],
-                                       [pragmas: ['Skip-func-hw-test-medium: true'],
+                                       [pragmas: ['Skip-func-hw-test-medium: true\n' +
+                                                  'Skip-func-hw-test-medium-verbs-provider: true\n' +
+                                                  'Skip-func-hw-test-medium-ucx-provider: true\n' +
+                                                  'Skip-func-hw-test-large: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), false, isPr(), true, !isPr(), isPr(), !isPr()]],
-                                       [pragmas: ['Skip-func-hw-test-medium-ucx-provider: false'],
+                                        skips: [isPr(), isPr(), false, isPr(), true, true, true, true]],
+                                       [pragmas: ['Skip-func-hw-test-medium: false\n' +
+                                                  'Skip-func-hw-test-medium-verbs-provider: false\n' +
+                                                  'Skip-func-hw-test-medium-ucx-provider: false\n' +
+                                                  'Skip-func-hw-test-large: false'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), false, isPr(), !isPr(), !isPr(), !isPr(), !isPr()]],
+                                        skips: [isPr(), isPr(), false, isPr(), false, false, false, false]],
                                        [pragmas: ['Run-daily-stages: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
                                         skips: [isPr(), isPr(), false, isPr(), false, false, false, false]],
-                                       [pragmas: ['Skip-build-el8-rpm: true'],
+                                       [pragmas: ['Skip-build-leap15-rpm: true\n' +
+                                                  'Skip-build-el7-rpm: true\n' +
+                                                  'Skip-build-el8-rpm: true\n' +
+                                                  'Skip-build-el9-rpm: true'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), true, isPr(), true, true, true, true]],
-                                       [pragmas: ['Skip-build-el9-rpm: true'],
+                                        skips: [true, true, true, true, true, true, true, true]],
+                                       [pragmas: ['Skip-build-leap15-rpm: false\n' +
+                                                  'Skip-build-el7-rpm: false\n' +
+                                                  'Skip-build-el8-rpm: false\n' +
+                                                  'Skip-build-el9-rpm: false'],
                                         /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [isPr(), isPr(), false, true, !isPr(), !isPr(), isPr(), !isPr()]],
-                                       [pragmas: ['Skip-build-leap15-rpm: true'],
-                                        /* groovylint-disable-next-line UnnecessaryGetter */
-                                        skips: [true, isPr(), false, isPr(), !isPr(), !isPr(), isPr(), !isPr()]]]
+                                        skips: [isPr(), isPr(), false, isPr(), !isPr(), !isPr(), isPr(), !isPr()]]]
                             errors = 0
                             commits.each { commit ->
                                 cm = 'Test commit\n\n'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -486,9 +486,7 @@ pipeline {
                                 println('-------------------------')
                                 println('Unit test commit message:')
                                 println('')
-                                println('  pragmas:        ' + commit.pragmas)
-                                println('  commit message: ' + cm)
-                                println('')
+                                println(cm)
                                 actual_skips = []
                                 i = 0
                                 // assign Map to env. var to serialize it

--- a/vars/functionalTest.groovy
+++ b/vars/functionalTest.groovy
@@ -52,6 +52,9 @@
    *
    * config['test_tag']          Avocado tag to test.
    *                             Default determined by parseStageInfo().
+   *
+   * config['ftest_arg']         Functional test launch.py arguments.
+   *                             Default determined by parseStageInfo().
    */
 
 Map call(Map config = [:]) {
@@ -84,15 +87,15 @@ Map call(Map config = [:]) {
         stashes.add("${target_compiler}-build-vars")
     }
 
-    Map p = [:]
-    p['stashes'] = stashes
-    p['test_rpms'] = config.get('test_rpms', env.TEST_RPMS)
-    p['pragma_suffix'] = stage_info['pragma_suffix']
-    p['test_tag'] =  config.get('test_tag', stage_info['test_tag'])
-    p['node_count'] = stage_info['node_count']
-    p['ftest_arg'] = stage_info['ftest_arg']
-    p['context'] = context
-    p['description'] = description
+    Map run_test_config = [:]
+    run_test_config['stashes'] = stashes
+    run_test_config['test_rpms'] = config.get('test_rpms', env.TEST_RPMS)
+    run_test_config['pragma_suffix'] = stage_info['pragma_suffix']
+    run_test_config['test_tag'] =  config.get('test_tag', stage_info['test_tag'])
+    run_test_config['node_count'] = stage_info['node_count']
+    run_test_config['ftest_arg'] = config.get('ftest_arg', stage_info['ftest_arg'])
+    run_test_config['context'] = context
+    run_test_config['description'] = description
 
     sh label: 'Install Launchable',
      script: '''# can't use --upgrade with pip3 because it tries to upgrade everything
@@ -120,9 +123,9 @@ Map call(Map config = [:]) {
     Map runtestData = [:]
     if (config.get('test_function', 'runTestFunctional') ==
       'runTestFunctionalV2') {
-        runtestData = runTestFunctionalV2 p
+        runtestData = runTestFunctionalV2 run_test_config
     } else {
-        runtestData = runTestFunctional p
+        runtestData = runTestFunctional run_test_config
     }
     runtestData.each { resultKey, data -> runData[resultKey] = data }
 

--- a/vars/getFunctionalArgs.groovy
+++ b/vars/getFunctionalArgs.groovy
@@ -25,9 +25,5 @@ Map call(Map kwargs = [:]) {
     }
 
     result['ftest_arg'] = [launch_nvme, launch_provider, launch_repeat].join(' ').trim()
-    println('getFunctionalArgs: launch_nvme     = ' + launch_nvme)
-    println('getFunctionalArgs: launch_provider = ' + launch_provider)
-    println('getFunctionalArgs: launch_repeat   = ' + launch_repeat)
-    println('getFunctionalArgs: ftest_arg       = ' + result['ftest_arg'])
     return result
 }

--- a/vars/getFunctionalArgs.groovy
+++ b/vars/getFunctionalArgs.groovy
@@ -20,29 +20,29 @@ Map call(String pragma_suffix, String stage_tags, String default_tags, String nv
     result['stage_rpms'] = ''
 
     // Get the launch.py --nvme argument from either the build parameters or commit pragmas
-    launch_nvme = params.TestNvme ?: cachedCommitPragma(
+    String launch_nvme = params.TestNvme ?: cachedCommitPragma(
         'Test-nvme' + pragma_suffix, cachedCommitPragma('Test-nvme', nvme))
     if (launch_nvme) {
         result['ftest_arg'] += ' --nvme=' + launch_nvme
     }
 
     // Get the launch.py --provider argument from either the build parameters or commit pragmas
-    launch_provider = ftest_arg_provider ?: params.TestProvider ?: cachedCommitPragma(
-        'Test-provider' + pragma_suffix, cachedCommitPragma('Test-provider', provider))
+    String launch_provider = provider ?: params.TestProvider ?: cachedCommitPragma(
+        'Test-provider' + pragma_suffix, cachedCommitPragma('Test-provider', null))
     if (launch_provider) {
         result['ftest_arg'] += ' --provider=' +  launch_provider
+
+        // Include any additional rpms required for the provider
+        if (launch_provider.contains('ucx')) {
+            result['stage_rpms'] = 'mercury-ucx'
+        }
     }
 
     // Get the launch.py --repeat argument from either the build parameters or commit pragmas
-    launch_repeat = params.TestRepeat ?: cachedCommitPragma(
+    String launch_repeat = params.TestRepeat ?: cachedCommitPragma(
         'Test-repeat' + pragma_suffix, cachedCommitPragma('Test-repeat', null))
     if (launch_repeat) {
         result['ftest_arg'] += ' --repeat=' + launch_repeat
-    }
-    
-    // Determine any additional rpms needed for this stage
-    if (ftest_arg_provider && ftest_arg_provider.contains('ucx')) {
-        result['stage_rpms'] = 'mercury-ucx'
     }
 
     return result

--- a/vars/getFunctionalArgs.groovy
+++ b/vars/getFunctionalArgs.groovy
@@ -7,8 +7,6 @@
  *
  * @param kwargs Map containing the following optional arguments:
  *      pragma_suffix   commit pragma suffix for this stage, e.g. '-hw-large'
- *      stage_tags      launch.py tags to use to limit functional tests to those that fit the stage
- *      default_tags    launch.py tag argument to use when no parameter or commit pragma tags exist
  *      default_nvme    launch.py --nvme argument to use when no parameter or commit pragma exist
  *      provider        launch.py --provider argument to use
  * @return Map values to use with runTestFunctional:

--- a/vars/getFunctionalArgs.groovy
+++ b/vars/getFunctionalArgs.groovy
@@ -1,0 +1,49 @@
+// vars/getFunctionalArgs.groovy
+
+/**
+ * getFunctionalArgs.groovy
+ *
+ * Get a map of arguments used to run the functional tests in the stage.
+ *
+ * @param pragma_suffix commit pragma suffix for this stage, e.g. '-hw-large'
+ * @param stage_tags launch.py tags to use to limit functional tests to those that fit the stage
+ * @param default_tags default launch.py tags to use when no parameter or commit pragma tags exist
+ * @param nvme default launch.py --nvme argument to use
+ * @param provider default launch.py --provider argument to use
+ * @return Map values to use with runTestFunctional
+ */
+Map call(String pragma_suffix, String stage_tags, String default_tags, String nvme,
+         String provider) {
+    Map result = [:]
+    result['test_tag'] = getFunctionalTags(pragma_suffix, stage_tags, default_tags)
+    result['ftest_arg'] = ''
+    result['stage_rpms'] = ''
+
+    // Get the launch.py --nvme argument from either the build parameters or commit pragmas
+    launch_nvme = params.TestNvme ?: cachedCommitPragma(
+        'Test-nvme' + pragma_suffix, cachedCommitPragma('Test-nvme', nvme))
+    if (launch_nvme) {
+        result['ftest_arg'] += ' --nvme=' + launch_nvme
+    }
+
+    // Get the launch.py --provider argument from either the build parameters or commit pragmas
+    launch_provider = ftest_arg_provider ?: params.TestProvider ?: cachedCommitPragma(
+        'Test-provider' + pragma_suffix, cachedCommitPragma('Test-provider', provider))
+    if (launch_provider) {
+        result['ftest_arg'] += ' --provider=' +  launch_provider
+    }
+
+    // Get the launch.py --repeat argument from either the build parameters or commit pragmas
+    launch_repeat = params.TestRepeat ?: cachedCommitPragma(
+        'Test-repeat' + pragma_suffix, cachedCommitPragma('Test-repeat', null))
+    if (launch_repeat) {
+        result['ftest_arg'] += ' --repeat=' + launch_repeat
+    }
+    
+    // Determine any additional rpms needed for this stage
+    if (ftest_arg_provider && ftest_arg_provider.contains('ucx')) {
+        result['stage_rpms'] = 'mercury-ucx'
+    }
+
+    return result
+}

--- a/vars/getFunctionalNvme.groovy
+++ b/vars/getFunctionalNvme.groovy
@@ -1,0 +1,25 @@
+// vars/getFunctionalNvme.groovy
+
+/**
+ * getFunctionalNvme.groovy
+ *
+ * Get the launch.py --nvme argument for this functional test stage.
+ *
+ * @param kwargs Map containing the following optional arguments:
+ *      pragma_suffix   commit pragma suffix for this stage, e.g. '-hw-large'
+ *      default_nvme    launch.py --nvme argument to use when no parameter or commit pragma exist
+ * @return String value of the launch.py --nvme argument
+ */
+Map call(Map kwargs = [:]) {
+    String pragma_suffix = kwargs.get('pragma_suffix', getPragmaSuffix())
+    String default_nvme = kwargs.get('default_nvme', '')
+
+    // Get the launch.py --nvme argument from either the build parameters or commit pragmas
+    String launch_nvme = params.TestNvme ?: cachedCommitPragma(
+        'Test-nvme' + pragma_suffix, cachedCommitPragma('Test-nvme', default_nvme))
+
+    if (launch_nvme) {
+        launch_nvme += ' --nvme=' + launch_nvme
+    }
+    return launch_nvme
+}

--- a/vars/getFunctionalNvme.groovy
+++ b/vars/getFunctionalNvme.groovy
@@ -19,7 +19,7 @@ Map call(Map kwargs = [:]) {
         'Test-nvme' + pragma_suffix, cachedCommitPragma('Test-nvme', default_nvme))
 
     if (launch_nvme) {
-        launch_nvme += ' --nvme=' + launch_nvme
+        launch_nvme = '--nvme=' + launch_nvme
     }
     return launch_nvme
 }

--- a/vars/getFunctionalProvider.groovy
+++ b/vars/getFunctionalProvider.groovy
@@ -16,7 +16,7 @@ Map call(Map kwargs = [:]) {
         'Test-provider' + pragma_suffix, cachedCommitPragma('Test-provider', null))
 
     if (launch_provider) {
-        result['ftest_arg'] += ' --provider=' +  launch_provider
+        launch_provider = '--provider=' +  launch_provider
     }
     return launch_provider
 }

--- a/vars/getFunctionalProvider.groovy
+++ b/vars/getFunctionalProvider.groovy
@@ -1,0 +1,22 @@
+// vars/getFunctionalProvider.groovy
+
+/**
+ * getFunctionalProvider.groovy
+ *
+ * Get the launch.py --provider argument for this functional test stage.
+ *
+ * @param kwargs Map containing the following optional arguments:
+ *      pragma_suffix   commit pragma suffix for this stage, e.g. '-hw-large'
+ *      provider        launch.py --provider argument to use
+ * @return String value of the launch.py --nvme argument
+ */
+Map call(Map kwargs = [:]) {
+    String pragma_suffix = kwargs.get('pragma_suffix', getPragmaSuffix())
+    String launch_provider = kwargs['provider'] ?: params.TestProvider ?: cachedCommitPragma(
+        'Test-provider' + pragma_suffix, cachedCommitPragma('Test-provider', null))
+
+    if (launch_provider) {
+        result['ftest_arg'] += ' --provider=' +  launch_provider
+    }
+    return launch_provider
+}

--- a/vars/getFunctionalProvider.groovy
+++ b/vars/getFunctionalProvider.groovy
@@ -13,7 +13,7 @@
 Map call(Map kwargs = [:]) {
     String pragma_suffix = kwargs.get('pragma_suffix', getPragmaSuffix())
     String launch_provider = kwargs['provider'] ?: params.TestProvider ?: cachedCommitPragma(
-        'Test-provider' + pragma_suffix, cachedCommitPragma('Test-provider', null))
+        'Test-provider' + pragma_suffix, cachedCommitPragma('Test-provider', ''))
 
     if (launch_provider) {
         launch_provider = '--provider=' +  launch_provider

--- a/vars/getFunctionalRepeat.groovy
+++ b/vars/getFunctionalRepeat.groovy
@@ -15,7 +15,7 @@ Map call(Map kwargs = [:]) {
         'Test-repeat' + pragma_suffix, cachedCommitPragma('Test-repeat', null))
 
     if (launch_repeat) {
-        result['ftest_arg'] += ' --repeat=' + launch_repeat
+        launch_repeat = '--repeat=' + launch_repeat
     }
     return launch_repeat
 }

--- a/vars/getFunctionalRepeat.groovy
+++ b/vars/getFunctionalRepeat.groovy
@@ -12,7 +12,7 @@
 Map call(Map kwargs = [:]) {
     String pragma_suffix = kwargs.get('pragma_suffix', getPragmaSuffix())
     String launch_repeat = params.TestRepeat ?: cachedCommitPragma(
-        'Test-repeat' + pragma_suffix, cachedCommitPragma('Test-repeat', null))
+        'Test-repeat' + pragma_suffix, cachedCommitPragma('Test-repeat', ''))
 
     if (launch_repeat) {
         launch_repeat = '--repeat=' + launch_repeat

--- a/vars/getFunctionalRepeat.groovy
+++ b/vars/getFunctionalRepeat.groovy
@@ -1,0 +1,21 @@
+// vars/getFunctionalRepeat.groovy
+
+/**
+ * getFunctionalRepeat.groovy
+ *
+ * Get the launch.py --repeat argument for this functional test stage.
+ *
+ * @param kwargs Map containing the following optional arguments:
+ *      pragma_suffix   commit pragma suffix for this stage, e.g. '-hw-large'
+ * @return String value of the launch.py --repeat argument
+ */
+Map call(Map kwargs = [:]) {
+    String pragma_suffix = kwargs.get('pragma_suffix', getPragmaSuffix())
+    String launch_repeat = params.TestRepeat ?: cachedCommitPragma(
+        'Test-repeat' + pragma_suffix, cachedCommitPragma('Test-repeat', null))
+
+    if (launch_repeat) {
+        result['ftest_arg'] += ' --repeat=' + launch_repeat
+    }
+    return launch_repeat
+}

--- a/vars/getFunctionalStageTags.groovy
+++ b/vars/getFunctionalStageTags.groovy
@@ -1,0 +1,34 @@
+// vars/getFunctionalStageTags.groovy
+
+/**
+ * getFunctionalStageTags.groovy
+ *
+ * Get the avocado tags for the functional test stage used to ensure only appropriately configured
+ * test run in the stage.
+ *
+ * @return String value of tags used to limit tests to ones that will run in this stage
+ */
+ String call() {
+    String stage_name = env.STAGE_NAME ?: ''
+    String stage_tags = ''
+
+    if (stage_name.contains('Functional')) {
+        // stage_tags = 'vm'
+        stage_tags = '-hw'
+        if (stage_name.contains('Hardware')) {
+            stage_tags = 'hw,large'
+            if (stage_name.contains('Small')) {
+                stage_tags = 'hw,small'
+            } else if (stage_name.contains('Medium')) {
+                stage_tags = 'hw,medium,-provider'
+                if (stage_name.contains('Provider')) {
+                    stage_tags = 'hw,medium,provider'
+                }
+            } else if (stage_name.contains('Hardware 24')) {
+                stage_tags = 'hw,24'
+            }
+        }
+    }
+
+    return stage_tags
+ }

--- a/vars/getFunctionalTags.groovy
+++ b/vars/getFunctionalTags.groovy
@@ -1,0 +1,69 @@
+// vars/getFunctionalTags.groovy
+
+/**
+ * getFunctionalTags.groovy
+ *
+ */
+
+/*
+ * Get the tags defined by the commit pragma.
+ *
+ * @param pragma_suffix commit pragma suffix for this stage, e.g. '-hw-large'
+ * @return String value of the test tags defined in the commit message
+ */
+String get_commit_pragma_tags(String pragma_suffix) {
+    // Get the test tags defined in the commit message
+    String pragma_tag
+
+    // Use the tags defined by the stage-specific 'Test-tag-<stage>:' commit message pragma.  If those
+    // are not specified use the tags defined by the general 'Test-tag:' commit message pragma.
+    pragma_tag = commitPragma('Test-tag' + pragma_suffix, commitPragma('Test-tag', null))
+    if (pragma_tag) {
+        return pragma_tag
+    }
+
+    // If neither of the 'Test-tag*:' commit message pragmas are specified, use the 'Features:'
+    // commit message pragma to define the tags to use.
+    String features = commitPragma('Features', null)
+    if (features) {
+        // Features extend the standard pr testing tags to include tests run in daily or weekly builds
+        // that test the specified feature.
+        pragma_tag = 'pr'
+        for (feature in features.split(' ')) {
+            pragma_tag += ' daily_regression,' + feature
+            pragma_tag += ' full_regression,' + feature
+        }
+    }
+    return pragma_tag
+}
+
+/*
+ * Get the avocado test tags for the functional test stage.
+ *
+ * @param pragma_suffix commit pragma suffix for this stage, e.g. '-hw-large'
+ * @param stage_tags launch.py tags to use to limit functional tests to those that fit the stage
+ * @param default_tags default launch.py tags to use when no parameter or commit pragma tags exist
+ * @return String of test tags to run in the stage
+ */
+Map call(String pragma_suffix, String stage_tags, String default_tags) {
+    String requested_tags = ''
+    String stage_tags = ''
+
+    // Define the test tags to use in this stage
+    if (startedByUser() || startedByTimer() || startedByUpstream()) {
+        // Builds started by the user, a timer, or upstreeam should use the TestTag parameter
+        requested_tags = params.TestTag ?: default_tags
+    }
+    else {
+        // Builds started from a commit should use any commit pragma tags if defined
+        requested_tags = get_commit_pragma_tags(pragma_suffix) ?: default_tags
+    }
+    if (requested_tags) {
+        requested_tags = tags.trim()
+    }
+    for (group in requested_tags.split(' ')) {
+        stage_tags += group + (group != '+' : ',' + stage_tags ? '') + ' '
+    }
+
+    return stage_tags.trim()
+}

--- a/vars/getFunctionalTags.groovy
+++ b/vars/getFunctionalTags.groovy
@@ -62,7 +62,7 @@ Map call(String pragma_suffix, String stage_tags, String default_tags) {
         requested_tags = tags.trim()
     }
     for (group in requested_tags.split(' ')) {
-        stage_tags += group + (group != '+' : ',' + stage_tags ? '') + ' '
+        stage_tags += group + (group != '+' ? ',' + stage_tags : '') + ' '
     }
 
     return stage_tags.trim()

--- a/vars/getFunctionalTags.groovy
+++ b/vars/getFunctionalTags.groovy
@@ -47,7 +47,7 @@ String get_commit_pragma_tags(String pragma_suffix) {
  */
 Map call(String pragma_suffix, String stage_tags, String default_tags) {
     String requested_tags = ''
-    String stage_tags = ''
+    String tags = ''
 
     // Define the test tags to use in this stage
     if (startedByUser() || startedByTimer() || startedByUpstream()) {
@@ -62,8 +62,8 @@ Map call(String pragma_suffix, String stage_tags, String default_tags) {
         requested_tags = tags.trim()
     }
     for (group in requested_tags.split(' ')) {
-        stage_tags += group + (group != '+' ? ',' + stage_tags : '') + ' '
+        tags += group + (group != '+' ? ',' + stage_tags : '') + ' '
     }
 
-    return stage_tags.trim()
+    return tags.trim()
 }

--- a/vars/getFunctionalTags.groovy
+++ b/vars/getFunctionalTags.groovy
@@ -40,21 +40,29 @@ String get_commit_pragma_tags(String pragma_suffix) {
 /*
  * Get the avocado test tags for the functional test stage.
  *
- * @param pragma_suffix commit pragma suffix for this stage, e.g. '-hw-large'
- * @param stage_tags launch.py tags to use to limit functional tests to those that fit the stage
- * @param default_tags default launch.py tags to use when no parameter or commit pragma tags exist
+ * @param kwargs Map containing the following optional arguments:
+ *      pragma_suffix   commit pragma suffix for this stage, e.g. '-hw-large'
+ *      stage_tags      launch.py tags to use to limit functional tests to those that fit the stage
+ *      default_tags    launch.py tag argument to use when no parameter or commit pragma tags exist
  * @return String of test tags to run in the stage
  */
-Map call(String pragma_suffix, String stage_tags, String default_tags) {
+Map call(Map kwargs = [:]) {
+    String pragma_suffix = kwargs.get('pragma_suffix', getPragmaSuffix())
+    String stage_tags = kwargs.get('stage_tags', getFunctionalStageTags())
+    String default_tags = kwargs.get('default_tags', '')
     String requested_tags = ''
     String tags = ''
 
     // Define the test tags to use in this stage
-    if (startedByUser() || startedByTimer() || startedByUpstream()) {
-        // Builds started by the user, a timer, or upstreeam should use the TestTag parameter
-        requested_tags = params.TestTag ?: default_tags
+    if (startedByUser() || startedByUpstream()) {
+        // Builds started by the user or upstreeam should use the TestTag parameter
+        requested_tags = params.TestTag ?: ''
     }
-    else {
+    if (!requested_tags && startedByTimer()) {
+        // Builds started by a timer w/o a TestTag parameter should use the default tag
+        requested_tags = default_tags
+    }
+    if (!requested_tags) {
         // Builds started from a commit should use any commit pragma tags if defined
         requested_tags = get_commit_pragma_tags(pragma_suffix) ?: default_tags
     }

--- a/vars/getFunctionalTags.groovy
+++ b/vars/getFunctionalTags.groovy
@@ -51,7 +51,6 @@ Map call(Map kwargs = [:]) {
     String stage_tags = kwargs.get('stage_tags', getFunctionalStageTags())
     String default_tags = kwargs.get('default_tags', '')
     String requested_tags = ''
-    String tags = ''
 
     // Define the test tags to use in this stage
     if (startedByUser() || startedByUpstream()) {
@@ -67,8 +66,11 @@ Map call(Map kwargs = [:]) {
         requested_tags = get_commit_pragma_tags(pragma_suffix) ?: default_tags
     }
     if (requested_tags) {
-        requested_tags = tags.trim()
+        requested_tags = requested_tags.trim()
     }
+
+    // Add the stage tags to each requested tag
+    String tags = ''
     for (group in requested_tags.split(' ')) {
         tags += group + (group != '+' ? ',' + stage_tags : '') + ' '
     }

--- a/vars/getFunctionalTags.groovy
+++ b/vars/getFunctionalTags.groovy
@@ -28,11 +28,11 @@ Map call(Map kwargs = [:]) {
     }
     if (!requested_tags) {
         // Builds started from a commit should first use any commit pragma 'Test-tag*:' tags if defined
-        requested_tags = commitPragma('Test-tag' + pragma_suffix, commitPragma('Test-tag', null))
+        requested_tags = commitPragma('Test-tag' + pragma_suffix, commitPragma('Test-tag', ''))
     }
     if (!requested_tags) {
         // Builds started from a commit should then use any commit pragma 'Features:' tags if defined
-        String features = commitPragma('Features', null)
+        String features = commitPragma('Features', '')
         if (features) {
             // Features extend the standard pr testing tags to include tests run in daily or weekly builds
             // that test the specified feature.

--- a/vars/getPragmaSuffix.groovy
+++ b/vars/getPragmaSuffix.groovy
@@ -1,0 +1,42 @@
+// vars/getPragmaSuffix.groovy
+
+/**
+ * getPragmaSuffix.groovy
+ *
+ * Get the commit pragma suffix for this functional test stage
+ *
+ * @return String value containing the commit pragma suffix for this functional test stage
+ */
+ String call() {
+    String stage_name = env.STAGE_NAME ?: ''
+    String pragma_suffix = ''
+
+    if (stage_name.contains('Functional')) {
+        pragma_suffix = '-vm'
+        if (stage_name.contains('Hardware')) {
+            pragma_suffix = '-hw-large'
+            if (stage_name.contains('Small')) {
+                pragma_suffix = '-hw-small'
+            } else if (stage_name.contains('Medium')) {
+                pragma_suffix = '-hw-medium'
+                if (stage_name.contains('Provider')) {
+                    if (stage_name.contains('Verbs')) {
+                        pragma_suffix += '-verbs-provider'
+                    }
+                    else if (stage_name.contains('UCX')) {
+                        pragma_suffix += '-ucx-provider'
+                    }
+                    else if (stage_name.contains('TCP')) {
+                        pragma_suffix += '-tcp-provider'
+                    }
+                }
+            } else if (stage_name.contains('Hardware 24')) {
+                pragma_suffix = '-hw-24'
+            }
+        }
+        if (stage_name.contains('with Valgrind')) {
+            pragma_suffix = '-valgrind'
+        }
+    }
+    return pragma_suffix
+ }

--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -245,12 +245,8 @@ Map call(Map config = [:]) {
         kwargs['default_nvme'] = ftest_arg_nvme
         kwargs['provider'] = ftest_arg_provider
         functional_args = getFunctionalArgs(kwargs)
-        if (functional_args['ftest_arg']) {
-            result['ftest_arg'] = functional_args['ftest_arg']
-        }
-        if (functional_args['stage_rpms']) {
-            result['stage_rpms'] = functional_args['stage_rpms']
-        }
+        result['ftest_arg'] = functional_args.get('ftest_arg', '')
+        result['stage_rpms'] = functional_args.get('stage_rpms', '')
 
     } else if (stage_name.contains('Storage')) {
         if (env.NODELIST) {

--- a/vars/runTestFunctionalV2.groovy
+++ b/vars/runTestFunctionalV2.groovy
@@ -52,7 +52,7 @@ Map call(Map config = [:]) {
         test_rpms = true
     }
     config['script'] = 'TEST_TAG="' + config['test_tag'] + '" ' +
-                       "FTEST_ARG=${stage_info.get('ftest_arg', '')} " +
+                       'FTEST_ARG="' + config.get('ftest_arg', '') + '" ' +
                        'PRAGMA_SUFFIX="' + config['pragma_suffix'] + '" ' +
                        'NODE_COUNT="' + config['node_count'] + '" ' +
                        'OPERATIONS_EMAIL="' + env.OPERATIONS_EMAIL + '" ' +

--- a/vars/runTestFunctionalV2.groovy
+++ b/vars/runTestFunctionalV2.groovy
@@ -52,7 +52,7 @@ Map call(Map config = [:]) {
         test_rpms = true
     }
     config['script'] = 'TEST_TAG="' + config['test_tag'] + '" ' +
-                       'FTEST_ARG="' + config.get('ftest_arg', '') + '" ' +
+                       'FTEST_ARG="' + config['ftest_arg'] + '" ' +
                        'PRAGMA_SUFFIX="' + config['pragma_suffix'] + '" ' +
                        'NODE_COUNT="' + config['node_count'] + '" ' +
                        'OPERATIONS_EMAIL="' + env.OPERATIONS_EMAIL + '" ' +

--- a/vars/runTestFunctionalV2.groovy
+++ b/vars/runTestFunctionalV2.groovy
@@ -52,7 +52,7 @@ Map call(Map config = [:]) {
         test_rpms = true
     }
     config['script'] = 'TEST_TAG="' + config['test_tag'] + '" ' +
-                       'FTEST_ARG="' + config['ftest_arg'] + '" ' +
+                       "FTEST_ARG=${stage_info.get('ftest_arg', '')} " +
                        'PRAGMA_SUFFIX="' + config['pragma_suffix'] + '" ' +
                        'NODE_COUNT="' + config['node_count'] + '" ' +
                        'OPERATIONS_EMAIL="' + env.OPERATIONS_EMAIL + '" ' +

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -132,6 +132,7 @@ boolean skip_ftest(String distro, String target_branch, String tags) {
     return !paramsValue('CI_FUNCTIONAL_' + distro + '_TEST', true) ||
            // Temporarily skip EL9 until it's completely landed.
            distro in ['el9', 'ubuntu20'] ||
+           skip_stage_pragma('build-' + distro + '-rpm') ||
            skip_stage_pragma('test') ||
            skip_stage_pragma('func-test') ||
            skip_stage_pragma('func-test-vm') ||

--- a/vars/testsInStage.groovy
+++ b/vars/testsInStage.groovy
@@ -4,14 +4,12 @@
 /**
  * testsInStage.groovy
  *
- * testsInStage variable
- */
-
-/**
  * Method to return true/false if the stage has tests that match the tags
+ *
+ * @param tags String of functional test tags to use to check for matching tests
+ * @return boolean true if there are tests that match the tags
  */
-
-boolean call() {
+boolean call(String tags) {
     if (env.UNIT_TEST && env.UNIT_TEST == 'true') {
         println('Unit testing, so exiting "Get test list" with true')
         return true
@@ -30,11 +28,11 @@ boolean call() {
                              exit 0
                          fi
                          if [ -x list_tests.py ]; then
-                             if ./list_tests.py ''' + parseStageInfo()['test_tag'] + '''; then
+                             if ./list_tests.py ''' + tags + '''; then
                                  exit 0
                              fi
                          else
-                             if ./launch.py --list ''' + parseStageInfo()['test_tag'] + '''; then
+                             if ./launch.py --list ''' + tags + '''; then
                                  exit 0
                              fi
                          fi


### PR DESCRIPTION
Provide additional flexibility for passing launch.py tag, provider, and nvme argument values on a per stage and per branch basis.  Existing branch Jenkinsfile implementations will use the existing behavior.