### PR TITLE
DAOS-14252 build: Remove 2.2 from the list of test targets

### DIFF
--- a/vars/packageBuildingPipelineDAOS.groovy
+++ b/vars/packageBuildingPipelineDAOS.groovy
@@ -740,8 +740,7 @@ void call(Map pipeline_args) {
                         axis {
                             name 'BRANCH'
                             values 'master',
-                                   'release/2.4',
-                                   'release/2.2'
+                                   'release/2.4'
                         }
                     }
                     when {

--- a/vars/packageBuildingPipelineDAOSTest.groovy
+++ b/vars/packageBuildingPipelineDAOSTest.groovy
@@ -734,8 +734,7 @@ void call(Map pipeline_args) {
                         axis {
                             name 'TEST_BRANCH'
                             values 'master',
-                                   'release/2.4',
-                                   'release/2.2'
+                                   'release/2.4'
                         }
                     }
                     when {


### PR DESCRIPTION
- Remove 2.2 branch for the list of test targets when updating pre-requisites

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>