### PR TITLE
SRE-1981 Build: Set unstable on test error

### DIFF
--- a/vars/functionalTestPostV2.groovy
+++ b/vars/functionalTestPostV2.groovy
@@ -118,6 +118,6 @@ void call(Map config = [:]) {
             error.getMessage())
     }
     if (!ignore_failure && results['result'] == 'FAILURE') {
-        error "Failure detected with test harness or hardware."
+        unstable "Failure detected with test harness or hardware."
     }
 }


### PR DESCRIPTION
If any test error occurs in a functional test, make sure that the stage is set to unstable, not error, so that it does cause other testing to be aborted.

This will not change a stage from an error state to an unstable state.