### PR TITLE
Allow specifying downstream Test-tag value

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,7 +127,6 @@ pipeline {
                         script {
                             assert(daosLatestVersion('master', 'el8').matches(/2.5\.\d+.*/))
                             assert(daosLatestVersion('release/2.4', 'el8').matches(/2.[34]\.\d+.*/))
-                            assert(daosLatestVersion('release/2.2', 'el8').startsWith('2.2.'))
                         }
                     }
                 }
@@ -785,7 +784,8 @@ pipeline {
                             } // withCredentials
                             build job: 'daos-stack/daos/' + test_branch(env.TEST_BRANCH),
                                   parameters: [string(name: 'TestTag',
-                                                      value: 'load_mpi test_core_files test_pool_info_query'),
+                                                      value: cachedCommitPragma('Test-tag',
+                                                                                'load_mpi test_core_files test_pool_info_query')),
                                                string(name: 'CI_RPM_TEST_VERSION',
                                                       value: cachedCommitPragma('Test-skip-build', 'false') == 'true' ?
                                                                daosLatestVersion(env.TEST_BRANCH) : ''),

--- a/vars/getPriority.groovy
+++ b/vars/getPriority.groovy
@@ -13,9 +13,7 @@ String call() {
         p = '2'
     } else {
         node(label: 'lightweight') {
-            if (fileExists('.git')) {
-                p = cachedCommitPragma('Priority')
-            }
+            p = cachedCommitPragma('Priority')
         }
     }
 

--- a/vars/pragmasToEnv.groovy
+++ b/vars/pragmasToEnv.groovy
@@ -34,14 +34,11 @@ String call(String commit_message) {
  * Method to put the commit pragmas into the environment
  */
 Void call() {
-    String cmd = '''if [ -n "$GIT_CHECKOUT_DIR" ] && [ -d "$GIT_CHECKOUT_DIR" ]
-                    then
-                      cd "$GIT_CHECKOUT_DIR"
-                    fi
-                    git show -s --format=%B\n'''
-
-    env.COMMIT_MESSAGE = sh(label: 'pragmasToEnv: lookup commit message',
-                            script: cmd,
+    env.COMMIT_MESSAGE = sh(label: 'pragmasToEnv(): Get commit message',
+                            script: '''if [ -n "$GIT_CHECKOUT_DIR" ] && [ -d "$GIT_CHECKOUT_DIR" ]; then
+                                           cd "$GIT_CHECKOUT_DIR"
+                                       fi
+                                       git show -s --format=%B''',
                             returnStdout: true).trim()
     env.pragmas = pragmasToEnv(env.COMMIT_MESSAGE)
 


### PR DESCRIPTION
When performing downstream testing, take any "Test-tag:" pragma from the pipeline-lib PR and pass it to the downstream test jobs.