### PR TITLE
SRE-1975 test: replace -hw with vm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -580,7 +580,7 @@ pipeline {
                                         // Useful for debugging since Jenkins'
                                         // assert() is pretty lame
                                         // println('assert(' + parseStageInfo()['test_tag'] + " == ${cmp})")
-                                        assert(parseStageInfo()['test_tag'] == cmp : parseStageInfo()['test_tag'])
+                                        assert parseStageInfo()['test_tag'] == cmp : parseStageInfo()['test_tag']
                                     }
                                 }
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@
 // That PR should be landed with out deleting the PR branch.
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
-@Library(value='pipeline-lib@dbohning/sre-1975') _
+//@Library(value='pipeline-lib@my_branch_name') _
 
 /* groovylint-disable-next-line CompileStatic */
 job_status_internal = [:]
@@ -579,8 +579,8 @@ pipeline {
                                         cmp = cmp.replace('@stages.tag@', stage.tag)
                                         // Useful for debugging since Jenkins'
                                         // assert() is pretty lame
-                                        println('assert(' + parseStageInfo()['test_tag'] + " == ${cmp})")
-                                        assert(parseStageInfo()['test_tag'] == cmp)
+                                        // println('assert(' + parseStageInfo()['test_tag'] + " == ${cmp})")
+                                        assert(parseStageInfo()['test_tag'] == cmp, parseStageInfo()['test_tag'])
                                     }
                                 }
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@
 // That PR should be landed with out deleting the PR branch.
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
-@Library(value='pipeline-lib@dbohning/sre-1975') _
+//@Library(value='pipeline-lib@my_branch_name') _
 
 /* groovylint-disable-next-line CompileStatic */
 job_status_internal = [:]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -579,7 +579,7 @@ pipeline {
                                         cmp = cmp.replace('@stages.tag@', stage.tag)
                                         // Useful for debugging since Jenkins'
                                         // assert() is pretty lame
-                                        // println('assert(' + parseStageInfo()['test_tag'] + " == ${cmp})")
+                                        println('assert(' + parseStageInfo()['test_tag'] + " == ${cmp})")
                                         assert(parseStageInfo()['test_tag'] == cmp)
                                     }
                                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -577,10 +577,7 @@ pipeline {
                                              'COMMIT_MESSAGE=' + cm.stripIndent()]) {
                                         cmp = commit.tag_template.replace('@commits.value@', commit.tags[0].value)
                                         cmp = cmp.replace('@stages.tag@', stage.tag)
-                                        // Useful for debugging since Jenkins'
-                                        // assert() is pretty lame
-                                        // println('assert(' + parseStageInfo()['test_tag'] + " == ${cmp})")
-                                        assert(parseStageInfo()['test_tag'] == cmp), parseStageInfo()['test_tag']
+                                        assert(parseStageInfo()['test_tag'] == cmp), parseStageInfo()['test_tag'] + ' != ' + cmp
                                     }
                                 }
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -580,7 +580,7 @@ pipeline {
                                         // Useful for debugging since Jenkins'
                                         // assert() is pretty lame
                                         // println('assert(' + parseStageInfo()['test_tag'] + " == ${cmp})")
-                                        assert(parseStageInfo()['test_tag'] == cmp, parseStageInfo()['test_tag'])
+                                        assert(parseStageInfo()['test_tag'] == cmp : parseStageInfo()['test_tag'])
                                     }
                                 }
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -535,7 +535,7 @@ pipeline {
                         // lots more test cases could be cooked up, to be sure
                         script {
                             stages = [[name: 'Fake CentOS 7 Functional stage',
-                                       tag: '-hw'],
+                                       tag: 'vm'],
                                       [name: 'Fake CentOS 7 Functional Hardware Medium stage',
                                        tag: 'hw,medium,-provider'],
                                       [name: 'Fake CentOS 7 Functional Hardware Medium Provider stage',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -580,7 +580,7 @@ pipeline {
                                         // Useful for debugging since Jenkins'
                                         // assert() is pretty lame
                                         // println('assert(' + parseStageInfo()['test_tag'] + " == ${cmp})")
-                                        assert parseStageInfo()['test_tag'] == cmp : parseStageInfo()['test_tag']
+                                        assert(parseStageInfo()['test_tag'] == cmp), parseStageInfo()['test_tag']
                                     }
                                 }
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@
 // That PR should be landed with out deleting the PR branch.
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
-//@Library(value='pipeline-lib@my_branch_name') _
+@Library(value='pipeline-lib@dbohning/sre-1975') _
 
 /* groovylint-disable-next-line CompileStatic */
 job_status_internal = [:]

--- a/vars/getFunctionalStageTags.groovy
+++ b/vars/getFunctionalStageTags.groovy
@@ -13,8 +13,7 @@
     String stage_tags = ''
 
     if (stage_name.contains('Functional')) {
-        // stage_tags = 'vm'
-        stage_tags = '-hw'
+        stage_tags = 'vm'
         if (stage_name.contains('Hardware')) {
             stage_tags = 'hw,large'
             if (stage_name.contains('Small')) {


### PR DESCRIPTION
All VM tests in master and 2.4 are tagged with "vm", so you "vm" instead of "-hw".