### PR TITLE
SRE-2082 ci: Add more timing info to jenkins_result file

### DIFF
--- a/vars/jobStatusUpdate.groovy
+++ b/vars/jobStatusUpdate.groovy
@@ -12,7 +12,7 @@
 Void call(Map job_result, String stage, Map result) {
     echo "[jobStatus] Updating job result for stage ${stage} with result: ${result}"
     String stage_key = jobStatusKey(stage)
-    if (!job_result.containsKey("${stage_key}")) {
+    if (!job_result.containsKey(stage_key)) {
         job_result."${stage_key}" = [:]
     }
     result.each { key, value ->

--- a/vars/runTest.groovy
+++ b/vars/runTest.groovy
@@ -137,11 +137,14 @@ Map call(Map config = [:]) {
         }
     }
 
-    int runTime = durationSeconds(startDate)
+    Date endDate = new Date()
+    int runTime = durationSeconds(startDate, endDate)
 
     // We need to pass the rc to the post step.
     Map results = ['result_code': rc,
                    'result': status,
+                   'start_date': startDate,
+                   'end_date': endDate,
                    'runtest_time': runTime]
 
     String results_map = 'results_map_' + sanitizedStageName()


### PR DESCRIPTION
Added to the map that runTest returns. Also fix for jobStatusUpdate. It was previously overwriting the map each time.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>
