### PR TITLE
SRE-2145 ci: Add requiredResult

### DIFF
--- a/vars/unitTestPost.groovy
+++ b/vars/unitTestPost.groovy
@@ -99,7 +99,8 @@ void call(Map config = [:]) {
         discoverGitReferenceBuild(
           referenceJob: config.get('referenceJobName',
                                    'daos-stack/daos/master'),
-          scm: 'daos-stack/daos')
+          scm: 'daos-stack/daos',
+          requiredResult: 'UNSTABLE')
         recordIssues enabledForFailure: true,
                      failOnError: !results['ignore_failure'],
                      // parameter below removed with the warnings-ng 11.2.2

--- a/vars/unitTestPost.groovy
+++ b/vars/unitTestPost.groovy
@@ -103,9 +103,6 @@ void call(Map config = [:]) {
           requiredResult: 'UNSTABLE')
         recordIssues enabledForFailure: true,
                      failOnError: !results['ignore_failure'],
-                     // parameter below removed with the warnings-ng 11.2.2
-                     // possibly by mistake.
-                     // ignoreFailedBuilds: true,
                      ignoreQualityGate: true,
                      // Set qualitygate to 1 new "NORMAL" priority message
                      // Supporting messages to help identify causes of


### PR DESCRIPTION
The ignoreFailedBuilds parameter was removed in reaction to the warnings-ng plug api change. Adding the requiredResult parameter to the discoverGitReferenceBuild call should create the same behavior.

Doc-only: false