### PR TITLE
SRE-2155 ci: Fix typo in parameter name to be consistent with main Jenkins file

### DIFF
--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -225,7 +225,7 @@ boolean call(Map config = [:]) {
                    (docOnlyChange(target_branch) &&
                     prRepos('ubuntu20') == '') ||
                    prReposContains('ubuntu20', jobName()) ||
-                   skip_stage_pragma('build-ubuntu20-rpm')
+                   skip_stage_pragma('build-ubuntu20-deb')
         case 'Build on CentOS 8':
         case 'Build on EL 8':
         case 'Build on EL 8.8':

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -220,7 +220,7 @@ boolean call(Map config = [:]) {
                    prReposContains('leap15', jobName()) ||
                    skip_stage_pragma('build-leap15-rpm')
         case 'Build DEB on Ubuntu 20.04':
-            return paramsValue('CI_RPM_Ubuntu20_NOBUILD', false) ||
+            return paramsValue('CI_RPM_ubuntu20_NOBUILD', false) ||
                    paramsValue('CI_DEB_Ubuntu20_NOBUILD', false) ||
                    target_branch =~ branchTypeRE('weekly') ||
                    (docOnlyChange(target_branch) &&

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -220,7 +220,7 @@ boolean call(Map config = [:]) {
                    prReposContains('leap15', jobName()) ||
                    skip_stage_pragma('build-leap15-rpm')
         case 'Build DEB on Ubuntu 20.04':
-            return paramsValue('CI_RPM_ubuntu20_NOBUILD', false) ||
+            return paramsValue('CI_DEB_Ubuntu20_NOBUILD', false) ||
                    target_branch =~ branchTypeRE('weekly') ||
                    (docOnlyChange(target_branch) &&
                     prRepos('ubuntu20') == '') ||

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -221,6 +221,7 @@ boolean call(Map config = [:]) {
                    skip_stage_pragma('build-leap15-rpm')
         case 'Build DEB on Ubuntu 20.04':
             return paramsValue('CI_DEB_Ubuntu20_NOBUILD', false) ||
+                   paramsValue('CI_RPM_Ubuntu20_NOBUILD', false) ||
                    target_branch =~ branchTypeRE('weekly') ||
                    (docOnlyChange(target_branch) &&
                     prRepos('ubuntu20') == '') ||

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -220,8 +220,8 @@ boolean call(Map config = [:]) {
                    prReposContains('leap15', jobName()) ||
                    skip_stage_pragma('build-leap15-rpm')
         case 'Build DEB on Ubuntu 20.04':
-            return paramsValue('CI_DEB_Ubuntu20_NOBUILD', false) ||
-                   paramsValue('CI_RPM_Ubuntu20_NOBUILD', false) ||
+            return paramsValue('CI_RPM_Ubuntu20_NOBUILD', false) ||
+                   paramsValue('CI_DEB_Ubuntu20_NOBUILD', false) ||
                    target_branch =~ branchTypeRE('weekly') ||
                    (docOnlyChange(target_branch) &&
                     prRepos('ubuntu20') == '') ||

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -225,7 +225,7 @@ boolean call(Map config = [:]) {
                    (docOnlyChange(target_branch) &&
                     prRepos('ubuntu20') == '') ||
                    prReposContains('ubuntu20', jobName()) ||
-                   skip_stage_pragma('build-ubuntu20-deb')
+                   skip_stage_pragma('build-ubuntu20-rpm')
         case 'Build on CentOS 8':
         case 'Build on EL 8':
         case 'Build on EL 8.8':


### PR DESCRIPTION
DAOS Jenkins uses `CI_DEB_Ubuntu20_NOBUILD` parameter
https://github.com/daos-stack/daos/blob/ff4375a885a316cefcf6279d752a42eaf9ea197e/Jenkinsfile#L238
It does not work as pipeline-lib expect `CI_RPM_Ubuntu20_NOBUILD`

`Skip-build-ubuntu20-deb` pragma is modified for consistency.