### PR TITLE
DAOS-623 ci: Don't change '-' to '_' in variable

### DIFF
--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -102,7 +102,7 @@ boolean skip_ftest_hw(String size, String target_branch, String tags) {
         return false
     }
     String distro = (hwDistroTarget(size) =~ /([a-z]+)(\d+)(\.\d+)?/)[0][1..2].join('')
-    return !paramsValue('CI_' + size.replace('-', '_') + '_TEST', true) ||
+    return !paramsValue('CI_' + size + '_TEST', true) ||
            env.DAOS_STACK_CI_HARDWARE_SKIP == 'true' ||
            skip_stage_pragma('build-' + distro + '-rpm') ||
            skip_stage_pragma('test') ||


### PR DESCRIPTION
The name in Jenkinsfile has '-'.  Changing it to '_' means the defaults specified in Jenkinsfile don't actually get used for variables with inline dashes.