### PR TITLE
SRE-2248 Add buildDaosJob routine

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value='pipeline-lib@my_branch_name') _
+@Library(value='pipeline-lib@jemalmbe/sre-2248') _
 
 /* groovylint-disable-next-line CompileStatic */
 job_status_internal = [:]
@@ -754,27 +755,7 @@ pipeline {
                                                         'Skip-build: true' : '') +
                                                    (cachedCommitPragma('Skip-downstream-test', 'false') == 'true' ?
                                                             '\nSkip-test: true' : ''))
-                            build job: 'daos-stack/daos/' + setupDownstreamTesting.test_branch(env.TEST_BRANCH),
-                                  parameters: [string(name: 'TestTag',
-                                                      value: cachedCommitPragma(
-                                                        'Test-tag',
-                                                        'load_mpi test_core_files ' +
-                                                        'test_pool_info_query')),
-                                               string(name: 'CI_RPM_TEST_VERSION',
-                                                      value: cachedCommitPragma('Test-skip-build', 'false') == 'true' ?
-                                                               daosLatestVersion(env.TEST_BRANCH) : ''),
-                                               string(name: 'BuildPriority', value: params.BuildPriority),
-                                               booleanParam(name: 'CI_UNIT_TEST', value: false),
-                                               booleanParam(name: 'CI_FI_el8_TEST', value: true),
-                                               booleanParam(name: 'CI_FUNCTIONAL_el7_TEST', value: true),
-                                               booleanParam(name: 'CI_MORE_FUNCTIONAL_PR_TESTS', value: true),
-                                               booleanParam(name: 'CI_FUNCTIONAL_el8_TEST', value: true),
-                                               booleanParam(name: 'CI_FUNCTIONAL_leap15_TEST', value: true),
-                                               booleanParam(name: 'CI_SCAN_RPMS_el7_TEST', value: true),
-                                               booleanParam(name: 'CI_RPMS_el7_TEST', value: true),
-                                               booleanParam(name: 'CI_medium_TEST', value: true),
-                                               booleanParam(name: 'CI_large_TEST', value: false)
-                                              ]
+                            buildDaosJob()
                         } // steps
                         post {
                             success {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -750,12 +750,7 @@ pipeline {
                 stages {
                     stage('Test Library') {
                         steps {
-                            setupDownstreamTesting('daos-stack/daos', env.TEST_BRANCH,
-                                                   (cachedCommitPragma('Test-skip-build', 'false') == 'true' ?
-                                                        'Skip-build: true' : '') +
-                                                   (cachedCommitPragma('Skip-downstream-test', 'false') == 'true' ?
-                                                            '\nSkip-test: true' : ''))
-                            buildDaosJob()
+                            buildDaosJob(env.TEST_BRANCH, params.BuildPriority)
                         } // steps
                         post {
                             success {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,6 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value='pipeline-lib@my_branch_name') _
-@Library(value='pipeline-lib@jemalmbe/sre-2248') _
 
 /* groovylint-disable-next-line CompileStatic */
 job_status_internal = [:]

--- a/vars/buildDaosJob.groovy
+++ b/vars/buildDaosJob.groovy
@@ -1,0 +1,32 @@
+// vars/buildDaosJob.groovy
+
+  /**
+   * buildDaosJob step method.
+   *
+   * This is intended only for use in a Jenkinsfile in a Matrix stage.
+   * Builds a branch of DAOS based on env.TEST_BRANCH.
+   *
+   * The paramater names must match parameters that are the Jenkinsfile for
+   * DAOS master.
+   *
+   * @param config Map of parameters passed
+   *
+   */
+
+Map call(Map config = [:]) {
+    build job: 'daos-stack/daos/' + setupDownstreamTesting.test_branch(env.TEST_BRANCH),
+                parameters: [string(name: 'TestTag',
+                             value: 'load_mpi test_core_files'),
+                             // Maybe should only do this if Test-tag: provisioning?
+                             string(name: 'CI_RPM_TEST_VERSION',
+                                          value: daosLatestVersion(env.TEST_BRANCH)),
+                             string(name: 'BuildPriority', value: '2'),
+                             booleanParam(name: 'CI_FI_el8_TEST', value: true),
+                             booleanParam(name: 'CI_MORE_FUNCTIONAL_PR_TESTS', value: true),
+                             booleanParam(name: 'CI_FUNCTIONAL_el9_TEST', value: true),
+                             booleanParam(name: 'CI_FUNCTIONAL_el8_TEST', value: true),
+                             booleanParam(name: 'CI_FUNCTIONAL_leap15_TEST', value: true),
+                             booleanParam(name: 'CI_medium_TEST', value: false),
+                             booleanParam(name: 'CI_large_TEST', value: false)
+                            ]
+}

--- a/vars/buildDaosJob.groovy
+++ b/vars/buildDaosJob.groovy
@@ -9,7 +9,7 @@
    *
    */
 
-void call(String branch, Integer priority) {
+void call(String branch, String priority) {
     setupDownstreamTesting('daos-stack/daos', branch,
                            (cachedCommitPragma('Test-skip-build', 'false') == 'true' ?
                                                'Skip-build: true' : '') +
@@ -24,7 +24,7 @@ void call(String branch, Integer priority) {
                                       'test_pool_info_query')),
                              string(name: 'CI_RPM_TEST_VERSION',
                                     value: cachedCommitPragma('Test-skip-build', 'false') == 'true' ?
-                                             daosLatestVersion(env.TEST_BRANCH) : ''),
+                                             daosLatestVersion(branch) : ''),
                              string(name: 'BuildPriority', value: priority),
                              booleanParam(name: 'CI_FI_el8_TEST', value: true),
                              booleanParam(name: 'CI_MORE_FUNCTIONAL_PR_TESTS', value: true),


### PR DESCRIPTION
Add the buildDaosJob routine to simplify projects doing downstream build of DAOS in order to validate changes.