### PR TITLE
SRE-2507 common: do not report "Doc-only: true" for empty commit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,8 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value='pipeline-lib@my_branch_name') _
+// TO BE REMOVED BEFORE LANDING
+@Library(value="pipeline-lib@grom72/SRE-2507") _
 
 /* groovylint-disable-next-line CompileStatic */
 job_status_internal = [:]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,8 +18,6 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value='pipeline-lib@my_branch_name') _
-// TO BE REMOVED BEFORE LANDING
-@Library(value="pipeline-lib@grom72/SRE-2507") _
 
 /* groovylint-disable-next-line CompileStatic */
 job_status_internal = [:]

--- a/vars/docOnlyChange.groovy
+++ b/vars/docOnlyChange.groovy
@@ -28,6 +28,10 @@ boolean call(String target_branch) {
                       echo "Hrm.  Got an error fetching the target branch"
                       exit 0
                   fi
+                  if ! git diff --no-commit-id --name-only origin/${TARGET_BRANCH} HEAD | grep -q -e ".*"; then
+                    echo "Empty commit diff"
+                    exit 0
+                  fi
                   git diff --no-commit-id --name-only origin/${TARGET_BRANCH} HEAD |
                      grep -v -e "^docs/" -e "\\.md$" -e "^.*LICENSE.*$"'''
     }


### PR DESCRIPTION
Empty commit shall not be treated as `Doc-only: true`

Fix the problem introduced by https://github.com/daos-stack/pipeline-lib/pull/444:

https://build.hpdd.intel.com/job/daos-stack/job/daos/job/daily-2.6-testing/114/console

```
14:00:27  + TARGET_BRANCH=daily-2.6-testing
14:00:27  + set -uex
14:00:27  + git fetch origin daily-2.6-testing
14:00:27  From https://github.com/daos-stack/daos
14:00:27   * branch                daily-2.6-testing -> FETCH_HEAD
14:00:27  + git diff --no-commit-id --name-only origin/daily-2.6-testing HEAD
14:00:27  + grep -v -e '^docs/' -e '\.md$' -e '^.*LICENSE.*$'
14:00:27  Stage "Test" skipped due to when conditional
```