### PR TITLE
DAOS-16683 test: Add support for feature branches

### DIFF
--- a/vars/branchTypeRE.groovy
+++ b/vars/branchTypeRE.groovy
@@ -36,6 +36,10 @@ String call(String branch_type) {
             // Also support older branch names not ending in 'testing'
             return(testBranchRE())
 
+        case 'feature':
+            // Match a feature branch name
+            return(/^feature\//)
+
         default:
             error "Unsupported branch type: ${branch_type}"
     }

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -111,9 +111,7 @@ boolean skip_ftest_hw(String size, String target_branch, String tags) {
            skip_stage_pragma('func-test-hw-' + size) ||
            skip_stage_pragma('func-hw-test') ||
            skip_stage_pragma('func-hw-test-' + size) ||
-           ((env.BRANCH_NAME == 'master' ||
-             env.BRANCH_NAME =~ branchTypeRE('release')) &&
-            !(startedByTimer() || startedByUser())) ||
+           startedByLanding() ||
            (docOnlyChange(target_branch) &&
             prRepos(distro) == '') ||
            /* groovylint-disable-next-line UnnecessaryGetter */
@@ -125,6 +123,7 @@ boolean skip_if_unstable() {
         cachedCommitPragma('Allow-unstable-test').toLowerCase() == 'true' ||
         env.BRANCH_NAME == 'master' ||
         env.BRANCH_NAME =~ branchTypeRE('testing') ||
+        env.BRANCH_NAME =~ branchTypeRE('feature') ||
         env.BRANCH_NAME =~ branchTypeRE('release')) {
         return false
     }

--- a/vars/startedByLanding.groovy
+++ b/vars/startedByLanding.groovy
@@ -6,6 +6,8 @@
  * @return a Boolean indicating if this build was started by landing a commit
  */
 Boolean call(Map config = [:]) {
-  return (env.BRANCH_NAME == 'master' || env.BRANCH_NAME =~ branchTypeRE('release')) &&
-        !(startedByTimer() || startedByUser())
+  return (env.BRANCH_NAME == 'master' ||
+          env.BRANCH_NAME =~ branchTypeRE('release') ||
+          env.BRANCH_NAME =~ branchTypeRE('feature')) &&
+         !(startedByTimer() || startedByUser())
 }


### PR DESCRIPTION
Treat landing builds on feature branches the same as master. Treat skipping unstable builds on feature branches the same as master.