### PR TITLE
DAOS-16500 test: Run on Leap 15.6 with 15.5 RPMs

### DIFF
--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -103,7 +103,8 @@ Map call(Map config = [:]) {
             new_ci_target = cachedCommitPragma('LEAP15-target', result['target'])
         } else if (stage_name.contains('Leap 15.6')) {
             result['target'] = 'leap15'
-            result['distro_version'] = cachedCommitPragma('LEAP15-version', '15.6')
+            // Until a mock opensuse-leap-15.6-x86-64.cfg is available provision with 15.5
+            result['distro_version'] = cachedCommitPragma('LEAP15-version', '15.5')
             new_ci_target = cachedCommitPragma('LEAP15-target', result['target'])
         } else if (stage_name.contains('Leap 15')) {
             result['target'] = 'leap15'


### PR DESCRIPTION
Provision the Functional on Leap 15.6 stage with the 15.6 image but install daos 15.5 RPMs as building 15.6 daos RPMs is not yet supported.