### PR TITLE
SRE-2772 ci: get rid of link to hpdd artifactory

### DIFF
--- a/ci/provisioning/post_provision_config_common.sh
+++ b/ci/provisioning/post_provision_config_common.sh
@@ -21,7 +21,7 @@ if [ -n "$repo_files_pr" ]; then
         branch="${branch%:*}"
     fi
     # shellcheck disable=SC2034
-    REPO_FILE_URL="${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-do/job/repo-files/job/$branch/$build_number/artifact/"
+    REPO_FILE_URL="${JENKINS_URL:-http://jenkins-3.daos.hpc.amslabs.hpecorp.net/}job/daos-do/job/repo-files/job/$branch/$build_number/artifact/"
 fi
 
 . /etc/os-release

--- a/ci/provisioning/post_provision_config_nodes_EL_8.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_8.sh
@@ -62,7 +62,7 @@ install_mofed() {
     fi
 
     # Add a repo to install MOFED RPMS
-    repo_url=https://artifactory.dc.hpdd.intel.com/artifactory/mlnx_ofed/"$MLNX_VER_NUM-rhel$gversion"-x86_64/
+    repo_url=https://artifactory.daos.hpc.amslabs.hpecorp.net/artifactory/mlnx_ofed/"$MLNX_VER_NUM-rhel$gversion"-x86_64/
     dnf -y config-manager --add-repo="$repo_url"
     curl -L -O "$repo_url"RPM-GPG-KEY-Mellanox
     dnf -y config-manager --save --setopt="$(url_to_repo "$repo_url")".gpgcheck=1

--- a/vars/stepResult.groovy
+++ b/vars/stepResult.groovy
@@ -139,7 +139,7 @@ Void call(Map config= [:]) {
                          '\n\nIf you are receiving this e-mail, about a PR that is not yours, it is\n' +
                          'in error.\n\n' +
                          'Please accept my appologies and kindly forward this message to\n' +
-                         'brian.murrell@intel.com for investigation.\n\n' +
+                         'john.malmberg@hpe.com for investigation.\n\n' +
                          'Thank-you.\n\n\n' +
                          /* groovylint-disable-next-line GStringExpressionWithinString */
                          'BUILD_NUMBER=${BUILD_NUMBER}\n' +


### PR DESCRIPTION
Get rid of the tight connection to the hpdd.intel.com artifactory. Instead, use a generic address: `https://artifactory/`