### PR TITLE
DAOS-16661 ci: Ignore detail analysis of PMDK warnings in NLT

### DIFF
--- a/vars/unitTestPost.groovy
+++ b/vars/unitTestPost.groovy
@@ -102,6 +102,8 @@ void call(Map config = [:]) {
           scm: 'daos-stack/daos',
           requiredResult: 'UNSTABLE')
         recordIssues enabledForFailure: true,
+                     /* ignore warning/errors from PMDK logging system */
+                     filters: [excludeFile('pmdk/.+')],
                      failOnError: !results['ignore_failure'],
                      ignoreQualityGate: true,
                      // Set qualitygate to 1 new "NORMAL" priority message


### PR DESCRIPTION
NLT results analysis reports an error when it can not get source code of the reported warning.
PMDK reports warnings/errors via VOS logging system but the source code is not available.

Static analysis of NLT results does not work properly when
a warning source code is out of scope of the project.
An error is reported in such case and  the whole stage status
is changed to FAILURE.
```
[NLT results] [-ERROR-] Can't create fingerprints for some files:
[NLT results] [-ERROR-] - 'pmdk/.../src/common/set.c' file not found
...
[NLT results] Failing build because analysis result contains errors
```

To prevent this problem, all PMDK-related messages are filtered out.

NLT results Warnings section will include warnings but will not
provide any detail information about location of this warning
in the source code.

Based on existing format of nlt-errors.json file the most easy way
to filtered all PMDK messages is to use the predefined "pmdk/" preffix
in the fileName:
```
...
{
        "fileName": "pmdk/src/../src/common/set.c",
        "type": "warning in strict mode",
        "lineStart": 2796,
        "description": "warning in strict mode",
        "message": "util_replica_check() Possible silent data corruption. The unsafe shutdown detection (SDS) is not supported in the pool: /mnt/daos_0/e5737f5f-fa54-45d6-b081-9b2769921610/vos-1\nwarning in strict mode",
        "severity": "NORMAL"
},
...
```
The VOS logging system should ensure that the filename of each PMDK-related message starts with a "pmdk/" prefix.
The implementation of the solution is provided in https://github.com/daos-stack/daos/pull/14923 PR
