### PR TITLE
SRE-2920 ci: Simplify RPM Lint

### DIFF
--- a/vars/rpmlintMockResults.groovy
+++ b/vars/rpmlintMockResults.groovy
@@ -36,15 +36,13 @@ void call(String config, Boolean allow_errors=false, Boolean skip_rpmlint=false,
                     returnStatus: true)
 
     catchError(stageResult: 'UNSTABLE', buildResult: 'SUCCESS') {
-        if (result == 2 && allow_errors) {
+        if (result > 0 && allow_errors) {
             error('RPM Lint found errors, but allow_errors is true.')
-        } else if (result == 1) {
-            error('RPM Lint found warnings.\n')
         }
     }
 
     catchError(stageResult: 'UNSTABLE', buildResult: 'UNSTABLE') {
-        if (result == 2 && !allow_errors) {
+        if (result > 0 && !allow_errors) {
             error('RPM Lint found errors.')
         }
     }

--- a/vars/rpmlintMockResults.groovy
+++ b/vars/rpmlintMockResults.groovy
@@ -13,30 +13,6 @@
  * @param config Mock configuration name to check in
  * @param allow_errors Whether errors are allowd.  Defaults to false.
  */
-String warnings(String output) {
-    return extract(output, 'warnings')
-}
-
-String errors(String output) {
-    return extract(output, 'errors')
-}
-
-String extract(String output, String type) {
-    /* groovylint-disable-next-line VariableName */
-    String T
-    if (type == 'errors') {
-        T = 'E'
-    } else if (type == 'warnings') {
-        T = 'W'
-    } else {
-        error("Unsupported type ${type} passed to extract()")
-    }
-
-    return sh(label: "Extract ${type} from rpmlint output",
-              script: "echo \"${output}\" | grep ': ${T}: '",
-              returnStdout: true).trim()
-}
-
 /* groovylint-disable-next-line ParameterName */
 void call(String config, Boolean allow_errors=false, Boolean skip_rpmlint=false, String make_args='') {
     if (skip_rpmlint || config == 'not_applicable') {
@@ -47,8 +23,8 @@ void call(String config, Boolean allow_errors=false, Boolean skip_rpmlint=false,
     if (fileExists('utils/rpms/Makefile')) {
         chdir = 'utils/rpms/'
     }
-    String output = sh(label: 'RPM Lint built RPMs',
-                       script: 'cd ' + chdir + '\n' +
+    int result = sh(label: 'RPM Lint built RPMs',
+                    script: 'cd ' + chdir + '\n' +
                              /* groovylint-disable-next-line GStringExpressionWithinString */
                              '''name=$(make ''' + make_args + ''' show_NAME)
                                 if [ -f "$name".rpmlintrc ]; then
@@ -56,41 +32,25 @@ void call(String config, Boolean allow_errors=false, Boolean skip_rpmlint=false,
                                 fi
                                 rpmlint --ignore-unused-rpmlintrc "${rpmlint_args[@]}" ''' +
                                '$(ls /var/lib/mock/' + config + '/result/*.rpm | ' +
-                               'grep -v -e -debuginfo -e debugsource) || exit 0',
-                       returnStdout: true).trim()
-
-    int result = sh(label: 'Analyze rpmlint output',
-                    script: "read e w b < <(echo \"${output}\" | " +
-                          """sed -nEe '\$s/.*([0-9]+) errors, ([0-9]+) warnings, ([0-9]+) badness;.*/\\1 \\2 \\3/p')
-                               if [ "\$e" -gt 0 ]; then
-                                   exit 2
-                               elif [ "\$w" -gt 0 ]; then
-                                   exit 1
-                               fi
-                               exit 0""",
+                               'grep -v -e -debuginfo -e debugsource)',
                     returnStatus: true)
 
     catchError(stageResult: 'UNSTABLE', buildResult: 'SUCCESS') {
         if (result == 2 && allow_errors) {
-            error('RPM Lint found errors, but allow_errors is ' + allow_errors + ':\n' +
-                  errors(output) + '\n\n' +
-                  'And also found additional warnings that it would be nice to fix:\n' + warnings(output))
+            error('RPM Lint found errors, but allow_errors is true.')
         } else if (result == 1) {
-            error('RPM Lint found warnings:\n' + warnings(output))
+            error('RPM Lint found warnings.\n')
         }
-        return
     }
 
     catchError(stageResult: 'UNSTABLE', buildResult: 'UNSTABLE') {
         if (result == 2 && !allow_errors) {
-            error('RPM Lint found errors:\n' + errors(output) + '\n\n' +
-                  'And also found additional warnings that it would be nice to fix:\n' + warnings(output))
+            error('RPM Lint found errors.')
         }
-        return
     }
 
-    // the returns above in the catchError() blocks don't acutally seem to work
+    // Print success message if rpmlint exits with 0
     if (result == 0) {
-        echo('RPM Lint output:\n' + output)
+        echo 'RPM Lint passed with no errors or warnings.'
     }
 }


### PR DESCRIPTION
rpmlintMockResults.groovy was screen scraping the results of rpmlint 
to get additional information. With an updated to rpmlint, this broke.
Simplifying the script to just use rpmlint return code.