### PR TITLE
SRE-2932 Fix notifyBrokenBranch

### DIFF
--- a/vars/distroVersion.groovy
+++ b/vars/distroVersion.groovy
@@ -33,8 +33,8 @@ String call(String distro, String branch) {
     return ['el8':      ['master': '8.8',
                          '2.4':    '8.8',
                          '2.6':    '8.8'],
-            'el9':      ['master': '9.2',
-                         '2.6':    '9.2'],
+            'el9':      ['master': '9.4',
+                         '2.6':    '9.4'],
             'leap15':   ['master': '15.6',
                          '2.4':    '15.6',
                          '2.6':    '15.6'],
@@ -48,8 +48,8 @@ assert(call('leap15', 'master') == '15.6')
 assert(call('el8', '2.4') == '8.8')
 assert(call('el8', '2.6') == '8.8')
 assert(call('el8', 'master') == '8.8')
-assert(call('el9', 'master') == '9.2')
-assert(call('el9', '2.6') == '9.2')
+assert(call('el9', 'master') == '9.4')
+assert(call('el9', '2.6') == '9.4')
 
 /* Uncomment to do further testing
 env = [:]

--- a/vars/docOnlyChange.groovy
+++ b/vars/docOnlyChange.groovy
@@ -17,6 +17,7 @@ boolean call(String target_branch) {
     if (cachedCommitPragma('Doc-only').toLowerCase() == 'false') {
         return false
     }
+    String script
     if (fileExists('ci/doc_only_change.sh')) {
         script = 'CHANGE_ID=' + env.CHANGE_ID +
                  ' TARGET_BRANCH=' + target_branch +

--- a/vars/getFunctionalTestStage.groovy
+++ b/vars/getFunctionalTestStage.groovy
@@ -45,7 +45,7 @@ Map call(Map kwargs = [:]) {
 
     return {
         stage("${name}") {
-            // Get the tags for thge stage. Use either the build parameter, commit pragma, or
+            // Get the tags for the stage. Use either the build parameter, commit pragma, or
             // default tags. All tags are combined with the stage tags to ensure only tests that
             // 'fit' the cluster will be run.
             String tags = getFunctionalTags(

--- a/vars/packageBuildingPipeline.groovy
+++ b/vars/packageBuildingPipeline.groovy
@@ -535,7 +535,7 @@ void call(Map pipeline_args) {
                             }
                         }
                     } //stage('Build RPM on EL 9')
-                    stage('Build RPM on Leap 15.4') {
+                    stage('Build RPM on Leap 15.5') {
                         when {
                             beforeAgent true
                             expression { !skipStage() && distros.contains('leap15') }
@@ -555,19 +555,19 @@ void call(Map pipeline_args) {
                             sh label: 'Build package',
                                script: '''rm -rf artifacts/leap15/
                                           mkdir -p artifacts/leap15/
-                                          make CHROOT_NAME="opensuse-leap-15.4-x86_64" ''' +
+                                          make CHROOT_NAME="opensuse-leap-15.5-x86_64" ''' +
                                               'DISTRO_VERSION=' + parseStageInfo()['distro_version'] + ' ' +
                                        pipeline_args.get('make args', '') + ' chrootbuild ' +
                                        pipeline_args.get('add_make_targets', '')
                         }
                         post {
                             success {
-                                rpmlintMockResults('opensuse-leap-15.4-x86_64',
+                                rpmlintMockResults('opensuse-leap-15.5-x86_64',
                                                    pipeline_args.get('rpmlint_rpms_allow_errors', false),
                                                    pipeline_args.get('rpmlint_rpms_skip', false),
                                                    pipeline_args.get('make args', ''))
                                 sh label: 'Collect artifacts',
-                                   script: '''(cd /var/lib/mock/opensuse-leap-15.4-x86_64/result/ &&
+                                   script: '''(cd /var/lib/mock/opensuse-leap-15.5-x86_64/result/ &&
                                               cp -r . $OLDPWD/artifacts/leap15/)\n''' +
                                               pipeline_args.get('add_archiving_cmds', '').replace('<distro>',
                                                                                                   'leap15') +
@@ -584,7 +584,7 @@ void call(Map pipeline_args) {
                             }
                             unsuccessful {
                                 sh label: 'Build Log',
-                                   script: '''mockroot=/var/lib/mock/opensuse-leap-15.4-x86_64
+                                   script: '''mockroot=/var/lib/mock/opensuse-leap-15.5-x86_64
                                               ls -l $mockroot/result/
                                               cat $mockroot/result/{root,build}.log
                                               artdir=$PWD/artifacts/leap15
@@ -594,9 +594,9 @@ void call(Map pipeline_args) {
                             }
                             always {
                                 scrubSecret(pipeline_args['secret'],
-                                            '/var/lib/mock/opensuse-leap-15.4-x86_64/result/build.log')
+                                            '/var/lib/mock/opensuse-leap-15.5-x86_64/result/build.log')
                                 sh label: 'Collect config.log(s)',
-                                   script: '(if cd /var/lib/mock/opensuse-leap-15.4-x86_64/root/builddir/build/' +
+                                   script: '(if cd /var/lib/mock/opensuse-leap-15.5-x86_64/root/builddir/build/' +
                                           '''BUILD/*/; then
                                                    find . -name configure -printf %h\\\\n | \
                                                    while read dir; do

--- a/vars/parseStageInfo.groovy
+++ b/vars/parseStageInfo.groovy
@@ -79,6 +79,10 @@ Map call(Map config = [:]) {
             result['target'] = 'el8.6'
             result['distro_version'] = cachedCommitPragma('EL8.6-version', '8.6')
             new_ci_target = cachedCommitPragma('EL8.6-target', result['target'])
+        } else if (stage_name.contains('EL 8.8')) {
+            result['target'] = 'el8.8'
+            result['distro_version'] = cachedCommitPragma('EL8.8-version', '8.8')
+            new_ci_target = cachedCommitPragma('EL8.8-target', result['target'])
         } else if (stage_name.contains('EL 8')) {
             result['target'] = 'el8'
             result['distro_version'] = cachedCommitPragma('EL8-version',

--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -45,9 +45,6 @@
 /* groovylint-disable-next-line MethodSize */
 Map call(Map config = [:]) {
     /* groovylint-disable-next-line NoJavaUtilDate */
-    println("1 #### start ${env.STAGE_NAME} ##############################")
-    println("       provisionNodes ")
-    println("config = ${config}")
     Date startDate = new Date()
     String nodeString = config['NODELIST']
     List node_list = config['NODELIST'].split(',')
@@ -108,8 +105,6 @@ Map call(Map config = [:]) {
     String inst_rpms = config.get('inst_rpms', '')
     String inst_repos = config.get('inst_repos', '')
 
-    println("2 #### ${env.STAGE_NAME} ##############################")
-    println("       provisionNodes DAOS_STACK_REPO_SUPPORT ")
     List gpg_key_urls = []
     if (env.DAOS_STACK_REPO_SUPPORT != null) {
         gpg_key_urls.add(env.DAOS_STACK_REPO_SUPPORT + 'RPM-GPG-KEY-CentOS-7')
@@ -127,8 +122,6 @@ Map call(Map config = [:]) {
 
     if (!fileExists('ci/provisioning/log_cleanup.sh') ||
         !fileExists('ci/provisioning/post_provision_config.sh')) {
-    println("3 #### start ${env.STAGE_NAME} ##############################")
-    println("       provisionNodes using provisionNodesV1")
 
         return provisionNodesV1(config)
     }
@@ -162,8 +155,6 @@ Map call(Map config = [:]) {
     default:
             error "Unsupported distro type: ${distro_type}/distro: ${distro}"
     }
-    println("4 #### start ${env.STAGE_NAME} ##############################")
-    println("       provisionNodes setup the provision script")
     provision_script += ' ' +
                       'NODESTRING=' + nodeString + ' ' +
                       'CONFIG_POWER_ONLY=' + config_power_only + ' ' +
@@ -176,11 +167,7 @@ Map call(Map config = [:]) {
                       'ci/provisioning/post_provision_config.sh'
     new_config['post_restore'] = provision_script
     try {
-    println("5 #### start ${env.STAGE_NAME} ##############################")
-    println("       provisionNodes calling provisionNodesSystem ...")
         int rc = provisionNodesSystem(new_config)
-    println("5 #### start ${env.STAGE_NAME} ##############################")
-    println("       provisionNodes returned ${rc} from provisionNodesSystem ...")
         if (rc != 0) {
             stepResult name: env.STAGE_NAME, context: 'test', result: 'FAILURE'
             error 'One or more nodes failed post-provision configuration!'

--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -39,12 +39,15 @@
                      May be used in the future as SUSE free development
                      licenses do currently allow them to be used for
                      CI automation, and SUSE also has offered site licenses.
-   Prefix "leap":    Specifically OpenSUSE leap oprating system builds of
+   Prefix "leap":    Specifically OpenSUSE leap operating system builds of
                      Suse Linux Enterprise Server.
 */
 /* groovylint-disable-next-line MethodSize */
 Map call(Map config = [:]) {
     /* groovylint-disable-next-line NoJavaUtilDate */
+    println("1 #### start ${env.STAGE_NAME} ##############################")
+    println("       provisionNodes ")
+    println("config = ${config}")
     Date startDate = new Date()
     String nodeString = config['NODELIST']
     List node_list = config['NODELIST'].split(',')
@@ -105,6 +108,8 @@ Map call(Map config = [:]) {
     String inst_rpms = config.get('inst_rpms', '')
     String inst_repos = config.get('inst_repos', '')
 
+    println("2 #### ${env.STAGE_NAME} ##############################")
+    println("       provisionNodes DAOS_STACK_REPO_SUPPORT ")
     List gpg_key_urls = []
     if (env.DAOS_STACK_REPO_SUPPORT != null) {
         gpg_key_urls.add(env.DAOS_STACK_REPO_SUPPORT + 'RPM-GPG-KEY-CentOS-7')
@@ -122,6 +127,9 @@ Map call(Map config = [:]) {
 
     if (!fileExists('ci/provisioning/log_cleanup.sh') ||
         !fileExists('ci/provisioning/post_provision_config.sh')) {
+    println("3 #### start ${env.STAGE_NAME} ##############################")
+    println("       provisionNodes using provisionNodesV1")
+
         return provisionNodesV1(config)
     }
 
@@ -154,6 +162,8 @@ Map call(Map config = [:]) {
     default:
             error "Unsupported distro type: ${distro_type}/distro: ${distro}"
     }
+    println("4 #### start ${env.STAGE_NAME} ##############################")
+    println("       provisionNodes setup the provision script")
     provision_script += ' ' +
                       'NODESTRING=' + nodeString + ' ' +
                       'CONFIG_POWER_ONLY=' + config_power_only + ' ' +
@@ -166,7 +176,11 @@ Map call(Map config = [:]) {
                       'ci/provisioning/post_provision_config.sh'
     new_config['post_restore'] = provision_script
     try {
+    println("5 #### start ${env.STAGE_NAME} ##############################")
+    println("       provisionNodes calling provisionNodesSystem ...")
         int rc = provisionNodesSystem(new_config)
+    println("5 #### start ${env.STAGE_NAME} ##############################")
+    println("       provisionNodes returned ${rc} from provisionNodesSystem ...")
         if (rc != 0) {
             stepResult name: env.STAGE_NAME, context: 'test', result: 'FAILURE'
             error 'One or more nodes failed post-provision configuration!'

--- a/vars/sconsBuild.groovy
+++ b/vars/sconsBuild.groovy
@@ -65,7 +65,7 @@ Map call(Map config = [:]) {
    * config['stash_files']  Filename containing list of test files to stash.
    * config['stash_opt'] Boolean, stash tar of /opt in preference to install/**.  Default false.
    *   If present, those files will be placed in a stash name
-   *   of based on parsing the evironment variables of the
+   *   of based on parsing the environment variables of the
    *   <target-compiler[-build_type]-test>.  Additional stashes
    *   will be created for "install" and "build_vars" with similar
    *   prefixes.

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -504,6 +504,20 @@ boolean call(Map config = [:]) {
                     !run_default_skipped_stage('test-el-8.6-rpms')) ||
                    (rpmTestVersion() != '') ||
                    stageAlreadyPassed()
+        case 'Test EL 8.8 RPMs':
+        case 'Test RPMs on EL 8.8':
+            return !paramsValue('CI_RPMS_el8.8_TEST', true) ||
+                   target_branch =~ branchTypeRE('weekly') ||
+                   skip_stage_pragma('build-el8-rpm') ||
+                   skip_stage_pragma('test') ||
+                   skip_stage_pragma('test-rpms') ||
+                   skip_stage_pragma('test-el-8.8-rpms') ||
+                   docOnlyChange(target_branch) ||
+                   (quickFunctional() &&
+                    !paramsValue('CI_RPMS_el8_8_TEST', true) &&
+                    !run_default_skipped_stage('test-el-8.8-rpms')) ||
+                   (rpmTestVersion() != '') ||
+                   stageAlreadyPassed()
         case 'Test Leap 15 RPMs':
         case 'Test Leap 15.2 RPMs':
             // Skip by default as it doesn't pass with Leap15.3 due to

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -422,11 +422,19 @@ boolean call(Map config = [:]) {
         case 'Functional on EL 8.8':
             return skip_ftest('el8', target_branch, tags)
         case 'Functional on EL 9':
+            /* Allows manually disable Functional on EL 9 */
+            if (paramsValue('CI_FUNCTIONAL_el9_TEST', false) ) {
+                return true
+            }
             return skip_ftest('el9', target_branch, tags)
         case 'Functional on Leap 15':
         case 'Functional on Leap 15.4':
         case 'Functional on Leap 15.5':
         case 'Functional on Leap 15.6':
+            /* Allows manually disable Functional on Leap 15 */
+            if (paramsValue('CI_FUNCTIONAL_leap15_TEST', false) ) {
+                return true
+            }
             return skip_ftest('leap15', target_branch, tags)
         case 'Functional on Ubuntu 20.04':
             /* we don't do any testing on Ubuntu yet

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -423,7 +423,7 @@ boolean call(Map config = [:]) {
             return skip_ftest('el8', target_branch, tags)
         case 'Functional on EL 9':
             /* Allows manually disable Functional on EL 9 */
-            if (paramsValue('CI_FUNCTIONAL_el9_TEST', false) ) {
+            if (!paramsValue('CI_FUNCTIONAL_el9_TEST', false) ) {
                 return true
             }
             return skip_ftest('el9', target_branch, tags)
@@ -432,7 +432,7 @@ boolean call(Map config = [:]) {
         case 'Functional on Leap 15.5':
         case 'Functional on Leap 15.6':
             /* Allows manually disable Functional on Leap 15 */
-            if (paramsValue('CI_FUNCTIONAL_leap15_TEST', false) ) {
+            if (!paramsValue('CI_FUNCTIONAL_leap15_TEST', false) ) {
                 return true
             }
             return skip_ftest('leap15', target_branch, tags)

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -181,7 +181,7 @@ boolean call(Map config = [:]) {
         case 'checkpatch':
             return skip_stage_pragma('checkpatch')
         case 'Python Bandit check':
-            return skip_stage_pragma('python-bandit')
+            return true || skip_stage_pragma('python-bandit')
         case 'Build':
             // always build branch landings as we depend on lastSuccessfulBuild
             // always having RPMs in it

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -181,7 +181,7 @@ boolean call(Map config = [:]) {
         case 'checkpatch':
             return skip_stage_pragma('checkpatch')
         case 'Python Bandit check':
-            return true || skip_stage_pragma('python-bandit')
+            return skip_stage_pragma('python-bandit')
         case 'Build':
             // always build branch landings as we depend on lastSuccessfulBuild
             // always having RPMs in it
@@ -422,19 +422,11 @@ boolean call(Map config = [:]) {
         case 'Functional on EL 8.8':
             return skip_ftest('el8', target_branch, tags)
         case 'Functional on EL 9':
-            /* Allows manually disable Functional on EL 9 */
-            if (!paramsValue('CI_FUNCTIONAL_el9_TEST', false) ) {
-                return true
-            }
             return skip_ftest('el9', target_branch, tags)
         case 'Functional on Leap 15':
         case 'Functional on Leap 15.4':
         case 'Functional on Leap 15.5':
         case 'Functional on Leap 15.6':
-            /* Allows manually disable Functional on Leap 15 */
-            if (!paramsValue('CI_FUNCTIONAL_leap15_TEST', false) ) {
-                return true
-            }
             return skip_ftest('leap15', target_branch, tags)
         case 'Functional on Ubuntu 20.04':
             /* we don't do any testing on Ubuntu yet

--- a/vars/unitTest.groovy
+++ b/vars/unitTest.groovy
@@ -137,15 +137,6 @@ Map call(Map config = [:]) {
         }
     }
 
-    println("1 #### start ${env.STAGE_NAME} ##############################")
-    println("       unitTest  - provisionNodes ")
-    println("config = ${config}")
-    println("nodelist = ${nodelist}")
-    println("node_count = ${stage_info['node_count']}")
-    println("ci_target = ${stage_info['ci_target']}")
-    println("distro_version = ${stage_info['distro_version']}")
-    println("inst_rpms = ${inst_rpms}")
-    println("1 #### end ${env.STAGE_NAME} #################################")
     Map runData = provisionNodes(
                  NODELIST: nodelist,
                  node_count: stage_info['node_count'],
@@ -153,9 +144,6 @@ Map call(Map config = [:]) {
                           /([a-z]+)(.*)/)[0][1] + stage_info['distro_version'],
                  inst_repos: config.get('inst_repos', ''),
                  inst_rpms: inst_rpms)
-    println("2 #### start ${env.STAGE_NAME} ##############################")
-    println("       unitTest  - returned from provisionNodes runData=${runData}")
-    println("2 #### end ${env.STAGE_NAME} #################################")
 
     String target_stash = "${stage_info['target']}-${stage_info['compiler']}"
     if (stage_info['build_type']) {

--- a/vars/unitTest.groovy
+++ b/vars/unitTest.groovy
@@ -26,7 +26,7 @@
    * config['description']       Description to report for SCM status.
    *                             Default env.STAGE_NAME.
    *
-   * config['failure_artifacts'] Failure aritfifacts to return.
+   * config['failure_artifacts'] Failure artifacts to return.
    *                             Default env.STAGE_NAME.
    *
    * config['ignore_failure']    Ignore test failures.  Default false.
@@ -43,10 +43,10 @@
    *
    * config['node_count']        Count of nodes that will actually be used
    *                             the test.  Default will be based on the
-   *                             enviroment variables for the stage.
+   *                             environment variables for the stage.
    *
    * config['stashes']           List of stashes to use.  Default will be
-   *                             baed on the environment variables for the
+   *                             based on the environment variables for the
    *                             stage.
    *
    * config['target']            Target distribution, such as 'centos7',
@@ -61,16 +61,16 @@
    *                             SSH_KEY_ARGS and NODELIST environment
    *                             variables set.
    *
-   * config['timeout_time']      Timelimit for test run, not including
+   * config['timeout_time']      Time limit for test run, not including
    *                             provisioning time.
    *                             Default is 120 Minutes.
    *
-   * config['timeout_units']     Timelimit units.  Default is minutes.
+   * config['timeout_units']     Time limit units.  Default is minutes.
    *
-   * config['unstash_opt']       Unstash -opt-tar instead of -opt,
+   * config['unstash_opt']       Un-stash -opt-tar instead of -opt,
    *                             default is false.
    *
-   * config['unstash_tests']     Unstash -tests, default is true.
+   * config['unstash_tests']     Un-stash -tests, default is true.
    */
 
 Map afterTest(Map config, Map testRunInfo) {
@@ -137,6 +137,15 @@ Map call(Map config = [:]) {
         }
     }
 
+    println("1 #### start ${env.STAGE_NAME} ##############################")
+    println("       unitTest  - provisionNodes ")
+    println("config = ${config}")
+    println("nodelist = ${nodelist}")
+    println("node_count = ${stage_info['node_count']}")
+    println("ci_target = ${stage_info['ci_target']}")
+    println("distro_version = ${stage_info['distro_version']}")
+    println("inst_rpms = ${inst_rpms}")
+    println("1 #### end ${env.STAGE_NAME} #################################")
     Map runData = provisionNodes(
                  NODELIST: nodelist,
                  node_count: stage_info['node_count'],
@@ -144,6 +153,10 @@ Map call(Map config = [:]) {
                           /([a-z]+)(.*)/)[0][1] + stage_info['distro_version'],
                  inst_repos: config.get('inst_repos', ''),
                  inst_rpms: inst_rpms)
+    println("2 #### start ${env.STAGE_NAME} ##############################")
+    println("       unitTest  - returned from provisionNodes runData=${runData}")
+    println("2 #### end ${env.STAGE_NAME} #################################")
+
     String target_stash = "${stage_info['target']}-${stage_info['compiler']}"
     if (stage_info['build_type']) {
         target_stash += '-' + stage_info['build_type']


### PR DESCRIPTION
vars/notifyBrokenBranch.grooy:
  This routine was doing a lookup of the enviroment Map which is not
  allowed in the pipeline-lib sandboxed operation.