### PR TITLE
SRE-3104 ci: Use DAOS specific HTTPS_PROXY variable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value='pipeline-lib@my_branch_name') _
+@Library(value='pipeline-lib@grom72/sre-3104') _
 
 /* groovylint-disable-next-line CompileStatic */
 job_status_internal = [:]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -230,6 +230,7 @@ pipeline {
                         dockerfile {
                             filename 'docker/Dockerfile.el.8'
                             label 'docker_runner'
+                            additionalBuildArgs dockerBuildArgs()
                         }
                     }
                     steps {
@@ -269,7 +270,7 @@ pipeline {
                         dockerfile {
                             filename 'docker/Dockerfile.el.8'
                             label 'docker_runner'
-                            additionalBuildArgs dockerBuildArgs(cachebust: false, add_repos: false)
+                            additionalBuildArgs dockerBuildArgs(cachebust: false)
                         }
                     }
                     steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,6 @@
 // Then a second PR submitted to comment out the @Library line, and when it
 // is landed, both PR branches can be deleted.
 //@Library(value='pipeline-lib@my_branch_name') _
-@Library(value='pipeline-lib@grom72/sre-3104') _
 
 /* groovylint-disable-next-line CompileStatic */
 job_status_internal = [:]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,8 @@
 #!/usr/bin/env groovy
 /* groovylint-disable DuplicateListLiteral, DuplicateMapLiteral, DuplicateNumberLiteral */
 // groovylint-disable DuplicateStringLiteral, NestedBlockDepth, VariableName
-/* Copyright (C) 2019-2023 Intel Corporation
+/* Copyright 2019-2024 Intel Corporation
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
  * All rights reserved.
  *
  * This file is part of the DAOS Project. It is subject to the license terms

--- a/vars/buildRpm.groovy
+++ b/vars/buildRpm.groovy
@@ -70,7 +70,9 @@ Map call(Map config = [:]) {
     } else if (env.HTTPS_PROXY) {
         https_proxy = "${env.HTTPS_PROXY}"
     }
-    env_vars += ' HTTPS_PROXY=' + https_proxy
+    if (https_proxy) {
+        env_vars += ' HTTPS_PROXY=' + https_proxy
+    }
 
     String error_stage_result = 'FAILURE'
     String error_build_result = 'FAILURE'

--- a/vars/buildRpm.groovy
+++ b/vars/buildRpm.groovy
@@ -1,5 +1,9 @@
 /* groovylint-disable DuplicateStringLiteral, VariableName */
 // vars/buildRpm.groovy
+/*
+ * Copyright (C) 2020-2024 Intel Corporation
+ * Copyright (C) 2025 Hewlett Packard Enterprise Development LP
+ */
 
   /**
    * buildRpm step method
@@ -59,6 +63,14 @@ Map call(Map config = [:]) {
     if (config['chroot_name']) {
         env_vars = ' CHROOT_NAME=' + config['chroot_name']
     }
+
+    String https_proxy = ''
+    if (env.DAOS_HTTPS_PROXY) {
+        https_proxy = "${env.DAOS_HTTPS_PROXY}"
+    } else if (env.HTTPS_PROXY) {
+        https_proxy = "${env.HTTPS_PROXY}"
+    }
+    env_vars += ' HTTPS_PROXY=' + https_proxy
 
     String error_stage_result = 'FAILURE'
     String error_build_result = 'FAILURE'

--- a/vars/buildRpm.groovy
+++ b/vars/buildRpm.groovy
@@ -1,8 +1,8 @@
 /* groovylint-disable DuplicateStringLiteral, VariableName */
 // vars/buildRpm.groovy
 /*
- * Copyright (C) 2020-2024 Intel Corporation
- * Copyright (C) 2025 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2024 Intel Corporation
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
  */
 
   /**

--- a/vars/dockerBuildArgs.groovy
+++ b/vars/dockerBuildArgs.groovy
@@ -66,9 +66,9 @@ String call(Map config = [:]) {
 
     String https_proxy = ''
     if (env.DAOS_HTTPS_PROXY) {
-        https_proxy = "${env.DAOS_HTTPS_PROXY}"
+        https_proxy = env.DAOS_HTTPS_PROXY
     } else if (env.HTTPS_PROXY) {
-        https_proxy = "${env.HTTPS_PROXY}"
+        https_proxy = env.HTTPS_PROXY
     }
     if (https_proxy) {
         ret_str += ' --build-arg HTTPS_PROXY' + '="' + https_proxy + '"'

--- a/vars/dockerBuildArgs.groovy
+++ b/vars/dockerBuildArgs.groovy
@@ -65,6 +65,19 @@ String call(Map config = [:]) {
         }
     }
 
+/* For DEBUG purpose only */
+    if (env.HTTPS_PROXY) {
+        println ('env.HTTPS_PROXY = ' + env.HTTPS_PROXY)
+    } else {
+        println ('env.HTTPS_PROXY = NULL')
+    }
+/* For DEBUG purpose only */
+    if (env.DAOS_HTTPS_PROXY) {
+        println ('env.DAOS_HTTPS_PROXY = ' + env.DAOS_HTTPS_PROXY)
+    } else {
+        println ('env.DAOS_HTTPS_PROXY = NULL')
+    }
+
     String https_proxy = ''
     if (env.DAOS_HTTPS_PROXY) {
         https_proxy = "${env.DAOS_HTTPS_PROXY}"

--- a/vars/dockerBuildArgs.groovy
+++ b/vars/dockerBuildArgs.groovy
@@ -64,19 +64,6 @@ String call(Map config = [:]) {
         }
     }
 
-/* For DEBUG purpose only */
-    if (env.HTTPS_PROXY) {
-        println ('env.HTTPS_PROXY = ' + env.HTTPS_PROXY)
-    } else {
-        println ('env.HTTPS_PROXY = NULL')
-    }
-/* For DEBUG purpose only */
-    if (env.DAOS_HTTPS_PROXY) {
-        println ('env.DAOS_HTTPS_PROXY = ' + env.DAOS_HTTPS_PROXY)
-    } else {
-        println ('env.DAOS_HTTPS_PROXY = NULL')
-    }
-
     String https_proxy = ''
     if (env.DAOS_HTTPS_PROXY) {
         https_proxy = "${env.DAOS_HTTPS_PROXY}"

--- a/vars/dockerBuildArgs.groovy
+++ b/vars/dockerBuildArgs.groovy
@@ -1,8 +1,8 @@
 /* groovylint-disable DuplicateStringLiteral, VariableName */
 // vars/dockerBuildArgs.groovy
 /*
- * Copyright (C) 2020-2024 Intel Corporation
- * Copyright (C) 2025 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2024 Intel Corporation
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
  */
 
 Integer num_proc() {

--- a/vars/dockerBuildArgs.groovy
+++ b/vars/dockerBuildArgs.groovy
@@ -1,5 +1,9 @@
 /* groovylint-disable DuplicateStringLiteral, VariableName */
 // vars/dockerBuildArgs.groovy
+/*
+ * Copyright (C) 2020-2024 Intel Corporation
+ * Copyright (C) 2025 Hewlett Packard Enterprise Development LP
+ */
 
 Integer num_proc() {
     return sh(label: 'Get number of processors online',
@@ -55,10 +59,20 @@ String call(Map config = [:]) {
     }
 
     // pass through env. var.s
-    ['DAOS_LAB_CA_FILE_URL', 'REPO_FILE_URL', 'HTTP_PROXY', 'HTTPS_PROXY'].each { var ->
+    ['DAOS_LAB_CA_FILE_URL', 'REPO_FILE_URL', 'HTTP_PROXY'].each { var ->
         if (env."$var") {
             ret_str += ' --build-arg ' + var + '="' + env."$var" + '"'
         }
+    }
+
+    String https_proxy = ''
+    if (env.DAOS_HTTPS_PROXY) {
+        https_proxy = "${env.DAOS_HTTPS_PROXY}"
+    } else if (env.HTTPS_PROXY) {
+        https_proxy = "${env.HTTPS_PROXY}"
+    }
+    if (https_proxy) {
+        ret_str += ' --build-arg HTTPS_PROXY' + '="' + https_proxy + '"'
     }
 
     if (config['qb']) {

--- a/vars/dockerBuildArgs.groovy
+++ b/vars/dockerBuildArgs.groovy
@@ -35,7 +35,6 @@ Integer num_proc() {
 
 String call(Map config = [:]) {
     Boolean cachebust = config.get('cachebust', true)
-    Boolean add_repos = config.get('add_repos', true)
     Boolean deps_build = config.get('deps_build', false)
     Boolean parallel_build = config.get('parallel_build', false)
 

--- a/vars/functionalTest.groovy
+++ b/vars/functionalTest.groovy
@@ -1,8 +1,8 @@
 /* groovylint-disable VariableName */
 // vars/functionalTest.groovy
 /*
- * Copyright (C) 2020-2024 Intel Corporation
- * Copyright (C) 2025 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2024 Intel Corporation
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
  */
 
   /**
@@ -114,7 +114,7 @@ Map call(Map config = [:]) {
     run_test_config['context'] = context
     run_test_config['description'] = description
 
-    String script = '''if ! pip3 install'''
+    String script = 'if ! pip3 install'
     if (env.DAOS_HTTPS_PROXY) {
         script += ' --proxy "' + env.DAOS_HTTPS_PROXY + '"'
     }

--- a/vars/functionalTest.groovy
+++ b/vars/functionalTest.groovy
@@ -1,5 +1,9 @@
 /* groovylint-disable VariableName */
 // vars/functionalTest.groovy
+/*
+ * Copyright (C) 2020-2024 Intel Corporation
+ * Copyright (C) 2025 Hewlett Packard Enterprise Development LP
+ */
 
   /**
    * functionalTest step method
@@ -110,8 +114,8 @@ Map call(Map config = [:]) {
     run_test_config['context'] = context
     run_test_config['description'] = description
 
-    sh label: 'Install Launchable',
-     script: '''if ! pip3 install --upgrade --upgrade-strategy only-if-needed launchable; then
+    String script = "HTTPS_PROXY=" +'"' + env.DAOS_HTTPS_PROXY + '"; '
+    script += '''if ! pip3 install --upgrade --upgrade-strategy only-if-needed launchable; then
                     set +e
                     echo "Failed to install launchable"
                     id
@@ -125,6 +129,8 @@ Map call(Map config = [:]) {
                 fi
                 pip3 list --user || true
                 '''
+    sh label: 'Install Launchable',
+       script: script
 
     try {
         withCredentials([string(credentialsId: 'launchable-test', variable: 'LAUNCHABLE_TOKEN')]) {

--- a/vars/functionalTest.groovy
+++ b/vars/functionalTest.groovy
@@ -114,9 +114,15 @@ Map call(Map config = [:]) {
     run_test_config['context'] = context
     run_test_config['description'] = description
 
-    String script = 'if ! pip3 install'
+    String https_proxy = ''
     if (env.DAOS_HTTPS_PROXY) {
-        script += ' --proxy "' + env.DAOS_HTTPS_PROXY + '"'
+        https_proxy = "${env.DAOS_HTTPS_PROXY}"
+    } else if (env.HTTPS_PROXY) {
+        https_proxy = "${env.HTTPS_PROXY}"
+    }
+    String script = 'if ! pip3 install'
+    if (https_proxy) {
+        script += ' --proxy "' + https_proxy + '"'
     }
     script += ''' --upgrade --upgrade-strategy only-if-needed launchable; then
                     set +e

--- a/vars/functionalTest.groovy
+++ b/vars/functionalTest.groovy
@@ -114,8 +114,11 @@ Map call(Map config = [:]) {
     run_test_config['context'] = context
     run_test_config['description'] = description
 
-    String script = "HTTPS_PROXY=" +'"' + env.DAOS_HTTPS_PROXY + '"; '
-    script += '''if ! pip3 install --upgrade --upgrade-strategy only-if-needed launchable; then
+    String script = '''if ! pip3 install'''
+    if (env.DAOS_HTTPS_PROXY) {
+        script += ' --proxy "' + env.DAOS_HTTPS_PROXY + '"'
+    }
+    script += ''' --upgrade --upgrade-strategy only-if-needed launchable; then
                     set +e
                     echo "Failed to install launchable"
                     id

--- a/vars/functionalTestPostV2.groovy
+++ b/vars/functionalTestPostV2.groovy
@@ -98,9 +98,15 @@ void call(Map config = [:]) {
            script: 'ci/functional/launchable_analysis "' + fileName + '"')
     }
 
-    String script = 'if pip3 install'
+    String https_proxy = ''
     if (env.DAOS_HTTPS_PROXY) {
-        script += ' --proxy "' + env.DAOS_HTTPS_PROXY + '"'
+        https_proxy = "${env.DAOS_HTTPS_PROXY}"
+    } else if (env.HTTPS_PROXY) {
+        https_proxy = "${env.HTTPS_PROXY}"
+    }
+    String script = 'if pip3 install'
+    if (https_proxy) {
+        script += ' --proxy "' + https_proxy + '"'
     }
     script += ' --user --upgrade launchable~=1.0'
 

--- a/vars/functionalTestPostV2.groovy
+++ b/vars/functionalTestPostV2.groovy
@@ -104,7 +104,7 @@ void call(Map config = [:]) {
     } else if (env.HTTPS_PROXY) {
         https_proxy = "${env.HTTPS_PROXY}"
     }
-    String script = 'if pip3 install'
+    String script = 'pip3 install'
     if (https_proxy) {
         script += ' --proxy "' + https_proxy + '"'
     }

--- a/vars/functionalTestPostV2.groovy
+++ b/vars/functionalTestPostV2.groovy
@@ -98,8 +98,15 @@ void call(Map config = [:]) {
            script: 'ci/functional/launchable_analysis "' + fileName + '"')
     }
 
+    String script = 'if pip3 install'
+    if (env.DAOS_HTTPS_PROXY) {
+        script += ' --proxy "' + env.DAOS_HTTPS_PROXY + '"'
+    }
+    script += ' --user --upgrade launchable~=1.0'
+
+
     sh(label: 'Install Launchable',
-       script: 'pip3 install --user --upgrade launchable~=1.0')
+       script: script)
 
     try {
         withCredentials([string(credentialsId: 'launchable-test', variable: 'LAUNCHABLE_TOKEN')]) {

--- a/vars/packageBuildingPipeline.groovy
+++ b/vars/packageBuildingPipeline.groovy
@@ -1,6 +1,6 @@
 #!/usr/bin/groovy
 /* groovylint-disable DuplicateMapLiteral, DuplicateStringLiteral, NestedBlockDepth */
-/* Copyright (C) 2019-2023 Intel Corporation
+/* Copyright 2019-2023 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/vars/packageBuildingPipelineDAOS.groovy
+++ b/vars/packageBuildingPipelineDAOS.groovy
@@ -1,6 +1,6 @@
 #!/usr/bin/groovy
 /* groovylint-disable DuplicateMapLiteral, DuplicateStringLiteral, NestedBlockDepth, VariableName */
-/* Copyright (C) 2019-2023 Intel Corporation
+/* Copyright 2019-2023 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/vars/packageBuildingPipelineDAOSTest.groovy
+++ b/vars/packageBuildingPipelineDAOSTest.groovy
@@ -1,7 +1,7 @@
 #!/usr/bin/groovy
 /* groovylint-disable DuplicateMapLiteral, DuplicateStringLiteral, NestedBlockDepth, VariableName */
-/* Copyright (C) 2019-2024 Intel Corporation
- * Copyright (C) 2025 Hewlett Packard Enterprise Development LP
+/* Copyright 2019-2024 Intel Corporation
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -1,5 +1,9 @@
 /* groovylint-disable DuplicateNumberLiteral, DuplicateStringLiteral, VariableName */
 // vars/provisionNodes.groovy
+/*
+ * Copyright 2020-2024 Intel Corporation
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
+ */
 
 /**
  * provisionNodes.groovy

--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -164,6 +164,7 @@ Map call(Map config = [:]) {
                       // https://issues.jenkins.io/browse/JENKINS-55819
                       'CI_RPM_TEST_VERSION="' + (params.CI_RPM_TEST_VERSION ?: '') + '" ' +
                       'CI_PR_REPOS="' + (params.CI_PR_REPOS ?: '') + '" ' +
+                      'HTTPS_PROXY="' + env.DAOS_HTTPS_PROXY + '" ' +
                       'ci/provisioning/post_provision_config.sh'
     new_config['post_restore'] = provision_script
     try {

--- a/vars/provisionNodes.groovy
+++ b/vars/provisionNodes.groovy
@@ -159,6 +159,12 @@ Map call(Map config = [:]) {
     default:
             error "Unsupported distro type: ${distro_type}/distro: ${distro}"
     }
+    String https_proxy = ''
+    if (env.DAOS_HTTPS_PROXY) {
+        https_proxy = "${env.DAOS_HTTPS_PROXY}"
+    } else if (env.HTTPS_PROXY) {
+        https_proxy = "${env.HTTPS_PROXY}"
+    }
     provision_script += ' ' +
                       'NODESTRING=' + nodeString + ' ' +
                       'CONFIG_POWER_ONLY=' + config_power_only + ' ' +
@@ -168,7 +174,7 @@ Map call(Map config = [:]) {
                       // https://issues.jenkins.io/browse/JENKINS-55819
                       'CI_RPM_TEST_VERSION="' + (params.CI_RPM_TEST_VERSION ?: '') + '" ' +
                       'CI_PR_REPOS="' + (params.CI_PR_REPOS ?: '') + '" ' +
-                      'HTTPS_PROXY="' + env.DAOS_HTTPS_PROXY + '" ' +
+                      'HTTPS_PROXY="' + https_proxy + '" ' +
                       'ci/provisioning/post_provision_config.sh'
     new_config['post_restore'] = provision_script
     try {


### PR DESCRIPTION
The `HTTPS_PROXY` variable set in Jenkins may force any shell script to use a proxy server.
This is not expected, as we want to avoid using a proxy unless it is explicitly needed by the DAOS tests or the build process.