### PR TITLE
sre-2257 - introduce NO_PROXY support for Dockers

### DIFF
--- a/vars/dockerBuildArgs.groovy
+++ b/vars/dockerBuildArgs.groovy
@@ -65,10 +65,10 @@ String call(Map config = [:]) {
     }
 
     if (env.REPO_FILE_URL) {
-        def url = new URL(env.REPO_FILE_URL)
-        def no_proxy = url.getHost()
-        println "no_proxy: $no_proxy"
-        ret_str += ' --build-arg no_proxy' + '="' + no_proxy + '"'
+        def url = env.REPO_FILE_URL
+        def DAOS_NO_PROXY = url.replaceFirst(/^https?:\/\//, '').split('/')[0].split(':')[0]
+        println "DAOS_NO_PROXY: $DAOS_NO_PROXY"
+        ret_str += ' --build-arg DAOS_NO_PROXY' + '="' + DAOS_NO_PROXY + '"'
     }
 
     String https_proxy = ''

--- a/vars/dockerBuildArgs.groovy
+++ b/vars/dockerBuildArgs.groovy
@@ -64,6 +64,13 @@ String call(Map config = [:]) {
         }
     }
 
+    if (env.REPO_FILE_URL) {
+        def url = new URL(env.REPO_FILE_URL)
+        def no_proxy = url.getHost()
+        println "no_proxy: $no_proxy"
+        ret_str += ' --build-arg no_proxy' + '="' + no_proxy + '"'
+    }
+
     String https_proxy = ''
     if (env.DAOS_HTTPS_PROXY) {
         https_proxy = env.DAOS_HTTPS_PROXY

--- a/vars/functionalTest.groovy
+++ b/vars/functionalTest.groovy
@@ -114,16 +114,7 @@ Map call(Map config = [:]) {
     run_test_config['context'] = context
     run_test_config['description'] = description
 
-    String https_proxy = ''
-    if (env.DAOS_HTTPS_PROXY) {
-        https_proxy = "${env.DAOS_HTTPS_PROXY}"
-    } else if (env.HTTPS_PROXY) {
-        https_proxy = "${env.HTTPS_PROXY}"
-    }
     String script = 'if ! pip3 install'
-    if (https_proxy) {
-        script += ' --proxy "' + https_proxy + '"'
-    }
     script += ''' --upgrade --upgrade-strategy only-if-needed launchable; then
                     set +e
                     echo "Failed to install launchable"

--- a/vars/functionalTestPostV2.groovy
+++ b/vars/functionalTestPostV2.groovy
@@ -98,18 +98,8 @@ void call(Map config = [:]) {
            script: 'ci/functional/launchable_analysis "' + fileName + '"')
     }
 
-    String https_proxy = ''
-    if (env.DAOS_HTTPS_PROXY) {
-        https_proxy = "${env.DAOS_HTTPS_PROXY}"
-    } else if (env.HTTPS_PROXY) {
-        https_proxy = "${env.HTTPS_PROXY}"
-    }
     String script = 'pip3 install'
-    if (https_proxy) {
-        script += ' --proxy "' + https_proxy + '"'
-    }
     script += ' --user --upgrade launchable~=1.0'
-
 
     sh(label: 'Install Launchable',
        script: script)


### PR DESCRIPTION
We need the mechanism to prevent CI to use proxy in case of access to local servers like artifactory.

`no_proxy` variable is passed to all Docker to not use proxy for pip installer and all other accesses to the `artifactory`

`--proxy` argument in no longer needed for the `pip install` command.
