### PR TITLE
DAOS-17472 build: Promote rpms to separate repos

### DIFF
--- a/vars/buildRpmPost.groovy
+++ b/vars/buildRpmPost.groovy
@@ -90,26 +90,22 @@ void call(Map config = [:]) {
         }
 
         String product = config.get('product', 'daos-stack')
+        String artdir = 'artifacts/' + target
         if (config.get('new_rpm', false)) {
-            publishToRepository product: product,
-                                format: repo_format,
-                                maturity: 'stable',
-                                tech: target,
-                                repo_dir: 'artifacts/' + target
-        } else {
             if (fileExists('artifacts/' + target + '/deps')) {
                 publishToRepository product: 'deps',
                                     format: repo_format,
                                     maturity: 'stable',
                                     tech: target,
-                                    repo_dir: 'artifacts/' + target + '/deps'
+                                    repo_dir: 'artifacts/deps/' + target
             }
-            publishToRepository product: product,
-                                format: repo_format,
-                                maturity: 'stable',
-                                tech: target,
-                                repo_dir: 'artifacts/' + target + '/daos'
+	    artdir = 'artifacts/' + target + '/daos'
         }
+        publishToRepository product: product,
+                            format: repo_format,
+                            maturity: 'stable',
+                            tech: target,
+                            repo_dir: artdir
 
         if (config.get('rpmlint', false)) {
             rpmlintMockResults(sh(label: 'Get chroot name',

--- a/vars/buildRpmPost.groovy
+++ b/vars/buildRpmPost.groovy
@@ -90,26 +90,26 @@ void call(Map config = [:]) {
         }
 
         String product = config.get('product', 'daos-stack')
-	if (config.get('new_rpm', false)) {
-	    publishToRepository product: product,
-	                        format: repo_format,
+        if (config.get('new_rpm', false)) {
+            publishToRepository product: product,
+                                format: repo_format,
                                 maturity: 'stable',
                                 tech: target,
                                 repo_dir: 'artifacts/' + target
         } else {
-	    if fileExists('artifacts/' + target + '/deps') {
-	        publishToRepository product: 'deps',
-	                            format: repo_format,
+            if fileExists('artifacts/' + target + '/deps') {
+                publishToRepository product: 'deps',
+                                    format: repo_format,
                                     maturity: 'stable',
                                     tech: target,
                                     repo_dir: 'artifacts/' + target + '/deps'
             }
-	    publishToRepository product: product,
-	                        format: repo_format,
+            publishToRepository product: product,
+                                format: repo_format,
                                 maturity: 'stable',
                                 tech: target,
                                 repo_dir: 'artifacts/' + target + '/daos'
-	}
+        }
 
         if (config.get('rpmlint', false)) {
             rpmlintMockResults(sh(label: 'Get chroot name',

--- a/vars/buildRpmPost.groovy
+++ b/vars/buildRpmPost.groovy
@@ -99,7 +99,7 @@ void call(Map config = [:]) {
                                     tech: target,
                                     repo_dir: 'artifacts/deps/' + target
             }
-	    artdir = 'artifacts/' + target + '/daos'
+            artdir = 'artifacts/' + target + '/daos'
         }
         publishToRepository product: product,
                             format: repo_format,

--- a/vars/buildRpmPost.groovy
+++ b/vars/buildRpmPost.groovy
@@ -49,6 +49,8 @@
    *
    * config['rpmlint']             Whether to run rpmlint on resulting RPMs.
    *                               Default false.
+   * config['new_rpm']             Whether we are using new RPM or not
+   *                               Default false
    *
    * config['unsuccessful_script'] Script to run if build is not successful.
    *                               Default 'ci/rpm/build_unsuccessful.sh'
@@ -88,11 +90,26 @@ void call(Map config = [:]) {
         }
 
         String product = config.get('product', 'daos-stack')
-        publishToRepository product: product,
-                            format: repo_format,
-                            maturity: 'stable',
-                            tech: target,
-                            repo_dir: 'artifacts/' + target
+	if (config.get('new_rpm', false)) {
+	    publishToRepository product: product,
+	                        format: repo_format,
+                                maturity: 'stable',
+                                tech: target,
+                                repo_dir: 'artifacts/' + target
+        } else {
+	    if fileExists('artifacts/' + target + '/deps') {
+	        publishToRepository product: 'deps',
+	                            format: repo_format,
+                                    maturity: 'stable',
+                                    tech: target,
+                                    repo_dir: 'artifacts/' + target + '/deps'
+            }
+	    publishToRepository product: product,
+	                        format: repo_format,
+                                maturity: 'stable',
+                                tech: target,
+                                repo_dir: 'artifacts/' + target + '/daos'
+	}
 
         if (config.get('rpmlint', false)) {
             rpmlintMockResults(sh(label: 'Get chroot name',

--- a/vars/buildRpmPost.groovy
+++ b/vars/buildRpmPost.groovy
@@ -97,7 +97,7 @@ void call(Map config = [:]) {
                                 tech: target,
                                 repo_dir: 'artifacts/' + target
         } else {
-            if fileExists('artifacts/' + target + '/deps') {
+            if (fileExists('artifacts/' + target + '/deps')) {
                 publishToRepository product: 'deps',
                                     format: repo_format,
                                     maturity: 'stable',


### PR DESCRIPTION
When building the new style RPMs, we need to publish dependencies to a different repo.
system-pipeline-lib uses the "product" and chooses the repo based on whether daos is in the name
so use this fact to publish dependencies, if built, to the dependency repo.

Change-Id: Iafe3932bbb7f2cfd5c5d2695cece9fa051130391