### PR TITLE
SRE-3665 Jenkinsfile: remove redundant libraries {}

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,9 +91,6 @@ Void distro_version_test(String branch, String distro, String expected) {
 /* groovylint-disable-next-line CompileStatic */
 pipeline {
     agent { label 'lightweight' }
-    libraries {
-        lib("pipeline-lib@${env.BRANCH_NAME}")
-    }
 
     environment {
         SSH_KEY_FILE = 'ci_key'


### PR DESCRIPTION
pipline-lib is loaded implicity. This call produces just this extra log message:

> Only using first definition of library pipeline-lib

Skip-daos-build-and-test: true