### PR TITLE
SRE-3636 ci: Unit Tests are not depends on el8

### DIFF
--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -346,7 +346,7 @@ boolean call(Map config = [:]) {
                     skip_stage_pragma('build') ||
                     rpmTestVersion() != '' ||
                     docOnlyChange(target_branch) ||
-                    skip_build_on_el_gcc(target_branch, '8') ||
+                    skip_build_on_el_gcc(target_branch, '9') ||
                     skip_stage_pragma('unit-tests')
         case 'NLT':
         case 'NLT on CentOS 8':


### PR DESCRIPTION
Unit Tests are now based on el9.
Skipping el8 build shall not affect the Unit Tests stage. Unit Tests stage shall be skipped only because of Build on EL 9 missing.
