### PR TITLE
SRE-3737 ci: HOT FIX - remove proxy related settings  for Fault Injection testing stage

### DIFF
--- a/vars/dockerBuildArgs.groovy
+++ b/vars/dockerBuildArgs.groovy
@@ -61,21 +61,23 @@ String call(Map config = [:]) {
         }
     }
 
-    if (env.DAOS_NO_PROXY) {
-        println "DAOS_NO_PROXY: $DAOS_NO_PROXY"
-        ret_str += ' --build-arg DAOS_NO_PROXY="' + env.DAOS_NO_PROXY + '"'
-    }
+    if (!(env.STAGE_NAME?.contains('Fault injection'))) {
+        if (env.DAOS_NO_PROXY) {
+            println "DAOS_NO_PROXY: $DAOS_NO_PROXY"
+            ret_str += ' --build-arg DAOS_NO_PROXY="' + env.DAOS_NO_PROXY + '"'
+        }
 
-    String https_proxy = ''
-    if (env.DAOS_HTTPS_PROXY) {
-        println "DAOS_HTTPS_PROXY: $DAOS_HTTPS_PROXY"
-        https_proxy = env.DAOS_HTTPS_PROXY
-    }
-    if (https_proxy) {
-        ret_str += ' --build-arg HTTPS_PROXY' + '="' + https_proxy + '"'
-        ret_str += ' --build-arg DAOS_HTTPS_PROXY' + '="' + https_proxy + '"'
-    } else {
-        println "WARNING: Missing DAOS_HTTPS_PROXY variable in Docker build arguments"
+        String https_proxy = ''
+        if (env.DAOS_HTTPS_PROXY) {
+            println "DAOS_HTTPS_PROXY: $DAOS_HTTPS_PROXY"
+            https_proxy = env.DAOS_HTTPS_PROXY
+        }
+        if (https_proxy) {
+            ret_str += ' --build-arg HTTPS_PROXY' + '="' + https_proxy + '"'
+            ret_str += ' --build-arg DAOS_HTTPS_PROXY' + '="' + https_proxy + '"'
+        } else {
+            println "WARNING: Missing DAOS_HTTPS_PROXY variable in Docker build arguments"
+        }
     }
 
     if (config['qb']) {


### PR DESCRIPTION
SRE-3737 ci: HOT FIX Fault Injection without proxy

Fault injection testing doesn't access the internet, so you don't need to use the `https_proxy` or `no_proxy` variables.

This PR is verified by https://github.com/daos-stack/daos/pull/18024.

This PR must land before https://github.com/daos-stack/daos/pull/18024.
