### PR TITLE
fix rpm test skip logic

### DIFF
--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -526,7 +526,7 @@ boolean call(Map config = [:]) {
                    skip_stage_pragma('build-el9-gcc') ||
                    skip_stage_pragma('test') ||
                    skip_stage_pragma('test-rpms') ||
-                   skip_stage_pragma('test-el-9-rpms', 'true') ||
+                   skip_stage_pragma('test-el-9-rpms') ||
                    docOnlyChange(target_branch) ||
                    (quickFunctional() &&
                     !paramsValue('CI_TEST_EL_RPMs', true) &&
@@ -544,17 +544,19 @@ boolean call(Map config = [:]) {
         case 'Test RPMs on Leap 15.4':
         case 'Test RPMs on Leap 15.5':
         case 'Test RPMs on Leap 15.6':
+        case 'Test RPMs on Leap 15':
             return !paramsValue('CI_RPMS_leap15_TEST', true) ||
                    target_branch =~ branchTypeRE('weekly') ||
                    skip_stage_pragma('build-leap15-rpm') ||
                    skip_stage_pragma('test') ||
                    skip_stage_pragma('test-rpms') ||
-                   skip_stage_pragma('test-leap-15-rpms', 'true') ||
+                   skip_stage_pragma('test-leap-15-rpms') ||
                    docOnlyChange(target_branch) ||
                    (quickFunctional() &&
                     !paramsValue('CI_RPMS_leap15_TEST', true) &&
                     !run_default_skipped_stage('test-leap-15-rpms')) ||
                    (rpmTestVersion() != '') ||
+                   !startedByLanding() ||
                    stageAlreadyPassed()
         case 'Test Packages':
             return docOnlyChange(target_branch)

--- a/vars/skipStage.groovy
+++ b/vars/skipStage.groovy
@@ -547,6 +547,9 @@ boolean call(Map config = [:]) {
         case 'Test RPMs on Leap 15.6':
         case 'Test RPMs on Leap 15.7':
         case 'Test RPMs on SLES 15':
+            if (startedByLanding()) {
+                return false
+            }
             return !paramsValue('CI_RPMS_leap15_TEST', true) ||
                    target_branch =~ branchTypeRE('weekly') ||
                    skip_stage_pragma('build-leap15-rpm') ||
@@ -558,7 +561,6 @@ boolean call(Map config = [:]) {
                     !paramsValue('CI_RPMS_leap15_TEST', true) &&
                     !run_default_skipped_stage('test-leap-15-rpms')) ||
                    (rpmTestVersion() != '') ||
-                   !startedByLanding() ||
                    stageAlreadyPassed()
         case 'Test Packages':
             return docOnlyChange(target_branch)


### PR DESCRIPTION
- Do not default to true for the skip pragma
- Do not skip test leap 15 RPMs for landing runs