### PR TITLE
SRE-3764 build: Support explicit distro DAOS packages

### DIFF
--- a/vars/daosPackagesVersion.groovy
+++ b/vars/daosPackagesVersion.groovy
@@ -32,10 +32,11 @@ String normalize_distro(String distro) {
 }
 
 String call(String next_version) {
-    return daosPackagesVersion(parseStageInfo()['target'], next_version)
+    Map info = parseStageInfo()
+    return daosPackagesVersion(info['target'], next_version, info['distro_version'])
 }
 
-String call(String distro, String next_version) {
+String call(String distro, String next_version, String distroVersion='') {
     String target_branch = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
     String _distro = distro
 
@@ -46,7 +47,7 @@ String call(String distro, String next_version) {
         String dist = ''
         if (version.indexOf('-') > -1) {
             // only tack on the %{dist} if the release was specified
-            dist = rpmDistValue(_distro)
+            dist = rpmDistValue(_distro, distroVersion)
         }
         return version + dist
     }
@@ -54,7 +55,7 @@ String call(String distro, String next_version) {
     if (target_branch =~ testBranchRE()) {
         // weekly-test just wants the latest for the branch
         if (rpm_version_cache != '' && rpm_version_cache != 'locked') {
-            return rpm_version_cache + rpmDistValue(_distro)
+            return rpm_version_cache + rpmDistValue(_distro, distroVersion)
         }
         if (rpm_version_cache == '') {
             // no cached value and nobody's getting it
@@ -71,7 +72,7 @@ String call(String distro, String next_version) {
                 rpm_version_cache = daosLatestVersion(next_version, _distro)
             }
         }
-        return rpm_version_cache + rpmDistValue(_distro)
+        return rpm_version_cache + rpmDistValue(_distro, distroVersion)
     }
 
     /* what's the query to get the highest 1.0.x package?

--- a/vars/daosPackagesVersion.groovy
+++ b/vars/daosPackagesVersion.groovy
@@ -32,30 +32,29 @@ String normalize_distro(String distro) {
 }
 
 String call(String next_version) {
-    Map info = parseStageInfo()
-    return daosPackagesVersion(info['target'], next_version, info['distro_version'])
+    return daosPackagesVersion(parseStageInfo()['target'], next_version)
 }
 
-String call(String distro, String next_version, String distroVersion='') {
+String call(String distro, String next_version, String rpmDistribution='') {
     String target_branch = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
     String _distro = distro
+    String distribution = rpmDistribution ?: rpmDistValue(_distro)
 
     // build parameter (CI_RPM_TEST_VERSION) has highest priority, followed by commit pragma
     // TODO: this should actually be determined from the PR-repos artifacts
     String version = rpmTestVersion()
     if (version != '') {
-        String dist = ''
         if (version.indexOf('-') > -1) {
             // only tack on the %{dist} if the release was specified
-            dist = rpmDistValue(_distro, distroVersion)
+            return version + distribution
         }
-        return version + dist
+        return version
     }
 
     if (target_branch =~ testBranchRE()) {
         // weekly-test just wants the latest for the branch
         if (rpm_version_cache != '' && rpm_version_cache != 'locked') {
-            return rpm_version_cache + rpmDistValue(_distro, distroVersion)
+            return rpm_version_cache + distribution
         }
         if (rpm_version_cache == '') {
             // no cached value and nobody's getting it
@@ -72,7 +71,7 @@ String call(String distro, String next_version, String distroVersion='') {
                 rpm_version_cache = daosLatestVersion(next_version, _distro)
             }
         }
-        return rpm_version_cache + rpmDistValue(_distro, distroVersion)
+        return rpm_version_cache + distribution
     }
 
     /* what's the query to get the highest 1.0.x package?

--- a/vars/functionalPackages.groovy
+++ b/vars/functionalPackages.groovy
@@ -66,9 +66,9 @@ String call(Map args) {
     Integer clientVersion = args.get('clientVersion', 1)
     String nextVersion = args.get('nextVersion', '')
     String addDaosPkgs = args.get('addDaosPkgs', null)
-    String distroVersion = args.get('distroVersion', '')
+    String rpmDistribution = args.get('rpmDistribution', '')
 
-    String daos_pkgs = getDAOSPackages(distro, nextVersion, addDaosPkgs, distroVersion)
+    String daos_pkgs = getDAOSPackages(distro, nextVersion, addDaosPkgs, rpmDistribution)
     String pkgs = ''
     if (fileExists('ci/functional/required_packages.sh')) {
         pkgs = sh(script: "ci/functional/required_packages.sh ${distro} " +

--- a/vars/functionalPackages.groovy
+++ b/vars/functionalPackages.groovy
@@ -14,7 +14,7 @@
 String call(Integer client_ver, BigDecimal next_version) {
     return functionalPackages(
         clientVersion: client_ver,
-        nextVersion: next_version.toString(),
+        nextVersion: next_version.toString()
     )
 }
 
@@ -29,18 +29,15 @@ String call(Integer client_ver, BigDecimal next_version, String add_daos_pkgs) {
 String call(Integer client_ver, String next_version) {
     return functionalPackages(
         clientVersion: client_ver,
-        nextVersion: next_version,
-        addDaosPkgs: null,
-        distroVersion: ''
+        nextVersion: next_version
     )
 }
 
-String call(Integer client_ver, String next_version, String add_daos_pkgs, String distroVersion='') {
+String call(Integer client_ver, String next_version, String add_daos_pkgs) {
     return functionalPackages(
         clientVersion: client_ver,
         nextVersion: next_version,
-        addDaosPkgs: add_daos_pkgs,
-        distroVersion: distroVersion
+        addDaosPkgs: add_daos_pkgs
     )
 }
 
@@ -64,9 +61,9 @@ String call(String distro, Integer client_ver, String next_version, String add_d
 String call(Map args) {
     String distro = args.get('distro', parseStageInfo()['target'])
     Integer clientVersion = args.get('clientVersion', 1)
-    String nextVersion = args.get('nextVersion', '')
+    String nextVersion = args.get('nextVersion', '1000').toString()
     String addDaosPkgs = args.get('addDaosPkgs', null)
-    String rpmDistribution = args.get('rpmDistribution', '')
+    String rpmDistribution = args.get('rpmDistribution', null)
 
     String daos_pkgs = getDAOSPackages(distro, nextVersion, addDaosPkgs, rpmDistribution)
     String pkgs = ''

--- a/vars/functionalPackages.groovy
+++ b/vars/functionalPackages.groovy
@@ -32,10 +32,11 @@ String call(String distro, Integer client_ver, String next_version) {
 }
 
 String call(String distro, Integer client_ver, String next_version, String add_daos_pkgs) {
-    String daos_pkgs = getDAOSPackages(distro, next_version.toString(), add_daos_pkgs)
+    String _distro = distro ?: parseStageInfo()['target']
+    String daos_pkgs = getDAOSPackages(_distro, next_version.toString(), add_daos_pkgs)
     String pkgs = ''
     if (fileExists('ci/functional/required_packages.sh')) {
-        pkgs = sh(script: "ci/functional/required_packages.sh ${distro} " +
+        pkgs = sh(script: "ci/functional/required_packages.sh ${_distro} " +
                           client_ver,
                   returnStdout: true)
     } else {
@@ -43,14 +44,14 @@ String call(String distro, Integer client_ver, String next_version, String add_d
              'Hopefully the daos-tests packages have the dependencies configured.'
     }
 
-    if (distro.startsWith('leap') || distro.startsWith('sles') ||
-        distro.startsWith('el') || distro.startsWith('centos') ||
-        distro.startsWith('rocky') || distro.startsWith('almalinux') ||
-        distro.startsWith('rhel') || distro.startsWith('ubuntu')) {
+    if (_distro.startsWith('leap') || _distro.startsWith('sles') ||
+        _distro.startsWith('el') || _distro.startsWith('centos') ||
+        _distro.startsWith('rocky') || _distro.startsWith('almalinux') ||
+        _distro.startsWith('rhel') || _distro.startsWith('ubuntu')) {
         return daos_pkgs + ' ' + pkgs
     }
 
-    error 'functionalPackages not implemented for ' + distro
+    error "functionalPackages not implemented for ${_distro}"
 
     return ''
 }

--- a/vars/functionalPackages.groovy
+++ b/vars/functionalPackages.groovy
@@ -12,46 +12,81 @@
  */
 
 String call(Integer client_ver, BigDecimal next_version) {
-    return functionalPackages(client_ver, next_version.toString(), null)
+    return functionalPackages(
+        clientVersion: client_ver,
+        nextVersion: next_version.toString(),
+    )
 }
 
 String call(Integer client_ver, BigDecimal next_version, String add_daos_pkgs) {
-    return functionalPackages(client_ver, next_version.toString(), add_daos_pkgs)
+    return functionalPackages(
+        clientVersion: client_ver,
+        nextVersion: next_version.toString(),
+        addDaosPkgs: add_daos_pkgs
+    )
 }
 
 String call(Integer client_ver, String next_version) {
-    return functionalPackages(client_ver, next_version, null)
+    return functionalPackages(
+        clientVersion: client_ver,
+        nextVersion: next_version,
+        addDaosPkgs: null,
+        distroVersion: ''
+    )
 }
 
-String call(Integer client_ver, String next_version, String add_daos_pkgs) {
-    return functionalPackages(parseStageInfo()['target'], client_ver, next_version, add_daos_pkgs)
+String call(Integer client_ver, String next_version, String add_daos_pkgs, String distroVersion='') {
+    return functionalPackages(
+        clientVersion: client_ver,
+        nextVersion: next_version,
+        addDaosPkgs: add_daos_pkgs,
+        distroVersion: distroVersion
+    )
 }
 
 String call(String distro, Integer client_ver, String next_version) {
-    return functionalPackages(distro, client_ver, next_version, null)
+    return functionalPackages(
+        distro: distro,
+        clientVersion: client_ver,
+        nextVersion: next_version
+    )
 }
 
 String call(String distro, Integer client_ver, String next_version, String add_daos_pkgs) {
-    String _distro = distro ?: parseStageInfo()['target']
-    String daos_pkgs = getDAOSPackages(_distro, next_version.toString(), add_daos_pkgs)
+    return functionalPackages(
+        distro: distro,
+        clientVersion: client_ver,
+        nextVersion: next_version,
+        addDaosPkgs: add_daos_pkgs
+    )
+}
+
+String call(Map args) {
+    String distro = args.get('distro', parseStageInfo()['target'])
+    Integer clientVersion = args.get('clientVersion', 1)
+    String nextVersion = args.get('nextVersion', '')
+    String addDaosPkgs = args.get('addDaosPkgs', null)
+    String distroVersion = args.get('distroVersion', '')
+
+    String daos_pkgs = getDAOSPackages(distro, nextVersion, addDaosPkgs, distroVersion)
     String pkgs = ''
     if (fileExists('ci/functional/required_packages.sh')) {
-        pkgs = sh(script: "ci/functional/required_packages.sh ${_distro} " +
-                          client_ver,
+        pkgs = sh(script: "ci/functional/required_packages.sh ${distro} " +
+                          clientVersion,
                   returnStdout: true)
     } else {
         echo "ci/functional/required_packages.sh doesn't exist.  " +
              'Hopefully the daos-tests packages have the dependencies configured.'
     }
 
-    if (_distro.startsWith('leap') || _distro.startsWith('sles') ||
-        _distro.startsWith('el') || _distro.startsWith('centos') ||
-        _distro.startsWith('rocky') || _distro.startsWith('almalinux') ||
-        _distro.startsWith('rhel') || _distro.startsWith('ubuntu')) {
+    if (distro.startsWith('leap') || distro.startsWith('sles') ||
+        distro.startsWith('el') || distro.startsWith('centos') ||
+        distro.startsWith('rocky') || distro.startsWith('almalinux') ||
+        distro.startsWith('rhel') || distro.startsWith('ubuntu')) {
         return daos_pkgs + ' ' + pkgs
     }
 
-    error "functionalPackages not implemented for ${_distro}"
+    error "functionalPackages not implemented for ${distro}"
 
     return ''
 }

--- a/vars/getDAOSPackages.groovy
+++ b/vars/getDAOSPackages.groovy
@@ -18,7 +18,7 @@ String call(String distro, String next_version) {
     return getDAOSPackages(distro, next_version, null)
 }
 
-String call(String distro, String next_version, String add_daos_pkgs) {
+String call(String distro, String next_version, String add_daos_pkgs, String distroVersion='') {
     String _add_daos_pkgs = ''
     if (add_daos_pkgs) {
         _add_daos_pkgs = ',-' + add_daos_pkgs
@@ -32,7 +32,7 @@ String call(String distro, String next_version, String add_daos_pkgs) {
         pkgs = 'daos{,-client}'
     }
 
-    String version = daosPackagesVersion(distro, next_version)
+    String version = daosPackagesVersion(distro, next_version, distroVersion)
 
     if (version) {
         if (distro.startsWith('ubuntu20')) {

--- a/vars/getDAOSPackages.groovy
+++ b/vars/getDAOSPackages.groovy
@@ -18,7 +18,7 @@ String call(String distro, String next_version) {
     return getDAOSPackages(distro, next_version, null)
 }
 
-String call(String distro, String next_version, String add_daos_pkgs, String distroVersion='') {
+String call(String distro, String next_version, String add_daos_pkgs, String rpmDistribution='') {
     String _add_daos_pkgs = ''
     if (add_daos_pkgs) {
         _add_daos_pkgs = ',-' + add_daos_pkgs
@@ -32,7 +32,7 @@ String call(String distro, String next_version, String add_daos_pkgs, String dis
         pkgs = 'daos{,-client}'
     }
 
-    String version = daosPackagesVersion(distro, next_version, distroVersion)
+    String version = daosPackagesVersion(distro, next_version, rpmDistribution)
 
     if (version) {
         if (distro.startsWith('ubuntu20')) {

--- a/vars/getFunctionalTestStage.groovy
+++ b/vars/getFunctionalTestStage.groovy
@@ -20,8 +20,9 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
  *      provider        launch.py --provider argument to use
  *      distro          functional test stage distro (VM)
  *      image_version   image version to use for provisioning, e.g. el8.8, leap15.6, etc.
- *      rpm_version     version to use for daos packages when installing on the test nodes;
- *                          if not specified, image_version will be used
+ *      rpm_distro      distribution to use for daos packages installed on the test nodes, e.g.
+ *                      '.el9', '.suse.lp156', etc.  If not specified, it will be determined by
+ *                      rpmDistValue(distro)
  *      base_branch     if specified, checkout sources from this branch before running tests
  *      other_packages  space-separated string of additional RPM packages to install
  *      run_if_pr       whether or not the stage should run for PR builds
@@ -41,7 +42,7 @@ Map call(Map kwargs = [:]) {
     String provider = kwargs.get('provider', '')
     String distro = kwargs.get('distro', null)
     String image_version = kwargs.get('image_version', null)
-    String rpm_version = kwargs.get('rpm_version', image_version)
+    String rpm_distro = kwargs.get('rpm_distro', null)
     String base_branch = kwargs.get('base_branch')
     String other_packages = kwargs.get('other_packages', '')
     Boolean run_if_pr = kwargs.get('run_if_pr', false)
@@ -91,7 +92,7 @@ Map call(Map kwargs = [:]) {
                                     clientVersion: 1,
                                     nextVersion: next_version,
                                     addDaosPkgs: 'tests-internal',
-                                    distroVersion: rpm_version) + ' ' + other_packages,
+                                    rpmDistribution: rpm_distro) + ' ' + other_packages,
                                 test_tag: tags,
                                 ftest_arg: getFunctionalArgs(
                                     pragma_suffix: pragma_suffix,

--- a/vars/getFunctionalTestStage.groovy
+++ b/vars/getFunctionalTestStage.groovy
@@ -88,10 +88,10 @@ Map call(Map kwargs = [:]) {
                                 image_version: image_version,
                                 inst_repos: daosRepos(distro),
                                 inst_rpms: functionalPackages(
-                                    distro: rpm_version,
-                                    client_ver: 1,
-                                    next_version: next_version,
-                                    add_daos_pkgs: 'tests-internal') + ' ' + other_packages,
+                                    clientVersion: 1,
+                                    nextVersion: next_version,
+                                    addDaosPkgs: 'tests-internal',
+                                    distroVersion: rpm_version) + ' ' + other_packages,
                                 test_tag: tags,
                                 ftest_arg: getFunctionalArgs(
                                     pragma_suffix: pragma_suffix,

--- a/vars/getFunctionalTestStage.groovy
+++ b/vars/getFunctionalTestStage.groovy
@@ -20,10 +20,10 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
  *      provider        launch.py --provider argument to use
  *      distro          functional test stage distro (VM)
  *      image_version   image version to use for provisioning, e.g. el8.8, leap15.6, etc.
+ *      rpm_version     version to use for daos packages when installing on the test nodes;
+ *                          if not specified, image_version will be used
  *      base_branch     if specified, checkout sources from this branch before running tests
  *      other_packages  space-separated string of additional RPM packages to install
- *      inst_rpms       space-separated string of RPM packages to install on the test nodes;
- *                          exclusive of other_packages.
  *      run_if_pr       whether or not the stage should run for PR builds
  *      run_if_landing  whether or not the stage should run for landing builds
  *      job_status      Map of status for each stage in the job/build
@@ -39,8 +39,9 @@ Map call(Map kwargs = [:]) {
     String nvme = kwargs.get('nvme')
     String default_nvme = kwargs.get('default_nvme')
     String provider = kwargs.get('provider', '')
-    String distro = kwargs.get('distro', '')
+    String distro = kwargs.get('distro', null)
     String image_version = kwargs.get('image_version', null)
+    String rpm_version = kwargs.get('rpm_version', image_version)
     String base_branch = kwargs.get('base_branch')
     String other_packages = kwargs.get('other_packages', '')
     Boolean run_if_pr = kwargs.get('run_if_pr', false)
@@ -87,7 +88,7 @@ Map call(Map kwargs = [:]) {
                                 image_version: image_version,
                                 inst_repos: daosRepos(distro),
                                 inst_rpms: functionalPackages(
-                                    distro: distro,
+                                    distro: rpm_version,
                                     client_ver: 1,
                                     next_version: next_version,
                                     add_daos_pkgs: 'tests-internal') + ' ' + other_packages,

--- a/vars/getFunctionalTestStage.groovy
+++ b/vars/getFunctionalTestStage.groovy
@@ -21,6 +21,9 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
  *      distro          functional test stage distro (VM)
  *      image_version   image version to use for provisioning, e.g. el8.8, leap15.6, etc.
  *      base_branch     if specified, checkout sources from this branch before running tests
+ *      other_packages  space-separated string of additional RPM packages to install
+ *      inst_rpms       space-separated string of RPM packages to install on the test nodes;
+ *                          exclusive of other_packages.
  *      run_if_pr       whether or not the stage should run for PR builds
  *      run_if_landing  whether or not the stage should run for landing builds
  *      job_status      Map of status for each stage in the job/build
@@ -36,7 +39,7 @@ Map call(Map kwargs = [:]) {
     String nvme = kwargs.get('nvme')
     String default_nvme = kwargs.get('default_nvme')
     String provider = kwargs.get('provider', '')
-    String distro = kwargs.get('distro')
+    String distro = kwargs.get('distro', '')
     String image_version = kwargs.get('image_version', null)
     String base_branch = kwargs.get('base_branch')
     String other_packages = kwargs.get('other_packages', '')
@@ -83,7 +86,11 @@ Map call(Map kwargs = [:]) {
                             functionalTest(
                                 image_version: image_version,
                                 inst_repos: daosRepos(distro),
-                                inst_rpms: functionalPackages(1, next_version, 'tests-internal') + ' ' + other_packages,
+                                inst_rpms: functionalPackages(
+                                    distro: distro,
+                                    client_ver: 1,
+                                    next_version: next_version,
+                                    add_daos_pkgs: 'tests-internal') + ' ' + other_packages,
                                 test_tag: tags,
                                 ftest_arg: getFunctionalArgs(
                                     pragma_suffix: pragma_suffix,

--- a/vars/rpmDistValue.groovy
+++ b/vars/rpmDistValue.groovy
@@ -10,7 +10,7 @@
  * Method to return the %{dist} value of an OS
  */
 
-String call(String distro, String distroVersion='') {
+String call(String distro) {
     if (distro.startsWith('el7') || distro.startsWith('centos7')) {
         return '.el7'
     } else if (distro.startsWith('el8') || distro.startsWith('centos8') ||
@@ -22,8 +22,7 @@ String call(String distro, String distroVersion='') {
                distro.startsWith('rhel9')) {
         return '.el9'
     } else if (distro.startsWith('leap15')) {
-        String version = distroVersion ?: parseStageInfo()['distro_version']
-        return '.suse.lp' + version.replaceAll('\\.', '')
+        return '.suse.lp' + parseStageInfo()['distro_version'].replaceAll('\\.', '')
     }
     error("Don't know what the RPM %{dist} is for ${distro}")
     return

--- a/vars/rpmDistValue.groovy
+++ b/vars/rpmDistValue.groovy
@@ -10,7 +10,7 @@
  * Method to return the %{dist} value of an OS
  */
 
-String call(String distro) {
+String call(String distro, String distroVersion='') {
     if (distro.startsWith('el7') || distro.startsWith('centos7')) {
         return '.el7'
     } else if (distro.startsWith('el8') || distro.startsWith('centos8') ||
@@ -22,7 +22,8 @@ String call(String distro) {
                distro.startsWith('rhel9')) {
         return '.el9'
     } else if (distro.startsWith('leap15')) {
-        return '.suse.lp' + parseStageInfo()['distro_version'].replaceAll('\\.', '')
+        String version = distroVersion ?: parseStageInfo()['distro_version']
+        return '.suse.lp' + version.replaceAll('\\.', '')
     }
     error("Don't know what the RPM %{dist} is for ${distro}")
     return


### PR DESCRIPTION
In order to run Leap 15.5 RPMs on nodes provisioned with 15.6 add the ability to override the distro used when determining the latest DAOS RPMs in timed *-testing branch builds instead of relying on parseStageInfo to extract this information from the stage name.