### PR TITLE
DAOS-19005 test: Pass trusted_host argument to ftest.sh

### DIFF
--- a/vars/functionalTest.groovy
+++ b/vars/functionalTest.groovy
@@ -59,6 +59,9 @@
    *
    * config['ftest_arg']         Functional test launch.py arguments.
    *                             Default determined by parseStageInfo().
+   *
+   * config['trusted_host']      Artifactory trusted host URL.  Default
+   *                             to the host in env.REPO_FILE_URL.
    */
 
 Map call(Map config = [:]) {
@@ -104,6 +107,12 @@ Map call(Map config = [:]) {
         stashes.add("${target_compiler}-build-vars")
     }
 
+    String trusted_host = config.get('trusted_host', '')
+    if (!trusted_host) {
+        URI repoFileUrl = new URI(config.get('trusted_host', env.REPO_FILE_URL))
+        trusted_host = "${repoFileUrl.scheme}://${repoFileUrl.authority}"
+    }
+
     Map run_test_config = [:]
     run_test_config['stashes'] = stashes
     run_test_config['test_rpms'] = config.get('test_rpms', env.TEST_RPMS)
@@ -113,6 +122,7 @@ Map call(Map config = [:]) {
     run_test_config['ftest_arg'] = config.get('ftest_arg', stage_info['ftest_arg'])
     run_test_config['context'] = context
     run_test_config['description'] = description
+    run_test_config['trusted_host'] = trusted_host
 
     Map runtestData = [:]
     if (config.get('test_function', 'runTestFunctional') ==

--- a/vars/runTestFunctionalV2.groovy
+++ b/vars/runTestFunctionalV2.groovy
@@ -39,6 +39,8 @@ Map call(Map config = [:]) {
    *
    * config['description']  Description to report for SCM status.
    *                        Default env.STAGE_NAME.
+   * config['trusted_host']  Artifactory trusted host URL.  Default
+   *                         to the host in env.REPO_FILE_URL.
    */
 
     Map stage_info = parseStageInfo(config)
@@ -51,6 +53,11 @@ Map call(Map config = [:]) {
     if (config['test_rpms'] == 'true') {
         test_rpms = true
     }
+    String trusted_host = config.get('trusted_host', '')
+    if (!trusted_host) {
+        URI repoFileUrl = new URI(config.get('trusted_host', env.REPO_FILE_URL))
+        trusted_host = "${repoFileUrl.scheme}://${repoFileUrl.authority}"
+    }
     config['script'] = 'TEST_TAG="' + config['test_tag'] + '" ' +
                        'FTEST_ARG="' + config['ftest_arg'] + '" ' +
                        'PRAGMA_SUFFIX="' + config['pragma_suffix'] + '" ' +
@@ -59,6 +66,7 @@ Map call(Map config = [:]) {
                        "WITH_VALGRIND=${stage_info.get('with_valgrind', '')} " +
                        (env.DAOS_HTTPS_PROXY ? 'DAOS_HTTPS_PROXY="' + env.DAOS_HTTPS_PROXY + '" ' : '') +
                        (env.DAOS_NO_PROXY ? 'DAOS_NO_PROXY="' + env.DAOS_NO_PROXY + '" ' : '') +
+                       'TRUSTED_HOST="' + trusted_host + '" ' +
                        'ci/functional/test_main.sh'
 
     String basedir = 'install/lib/daos/TESTING/ftest/avocado/job-results/'


### PR DESCRIPTION
Tio support configuring a uv.toml file for functional tests, pass the atrifactory host, defined in env.REPO_FILE_URL through to ftest.sh.