### PR TITLE
SRE-3435 ci: downgrade RPMs for sles 15.7 to 15.6

### DIFF
--- a/vars/distroVersion.groovy
+++ b/vars/distroVersion.groovy
@@ -41,10 +41,8 @@ String call(String distro, String branch) {
                          '2.4':    '15.6',
                          '2.6':    '15.5',
                          '2.8':    '15.6'],
-            'sles15':   ['master': '15.7',
-                         '2.4':    '15.7',
-                         '2.6':    '15.7',
-                         '2.8':    '15.7'],
+            'sles15':   ['master': '15.6',
+                         '2.8':    '15.6'],
             'ubuntu20': ['master': '20.04']][distro][branch]
 }
 


### PR DESCRIPTION
RPMs for SLES 15.7 (lp157) are not available.
Until SLES 15.7 RMPs are released, Leap 15.6 (lp156) must be used by default.

Tested by: https://github.com/daos-stack/daos/pull/18241

