### PR TITLE
SRE-3899 Add SCM checkout retry on git fetch failure

### DIFF
--- a/src/com/intel/checkoutScmInternal.groovy
+++ b/src/com/intel/checkoutScmInternal.groovy
@@ -17,10 +17,11 @@ Map checkoutScmInternal(Map config = [:]) {
    * @return Map of any variables the SCM plugin would set in a
    * Freestyle job.
    *
-   * config['scm'] SCM name, defaults to 'GitSCM'.
-   * config['url'] Url for SCM repository.  If not specified,
-   *  defaults will be used from the scm global variable.
-   * config['cleanAfterCheckout'] True for clean after checkout.
+    * config['scm'] SCM name, defaults to 'GitSCM'.
+    * config['url'] Url for SCM repository.  If not specified,
+    *  defaults will be used from the scm global variable.
+    * config['checkoutRetries'] Retry count override. Defaults to $SCM_CHECKOUT_RETRY_COUNT env var, then 1.
+    * config['cleanAfterCheckout'] True for clean after checkout.
    * config['checkoutDir'] Optional directory to checkout into.
    * config['branch'] Optional branch to checkout, defaults to master.
    * config['withSubmodules'] Optional checkout submodules if true.
@@ -92,5 +93,18 @@ Map checkoutScmInternal(Map config = [:]) {
            trackingSubmodules: false])
     }
 
-    return checkout(params)
+    int maxRetries = (config['checkoutRetries'] != null
+                      ? config['checkoutRetries']
+                      : (env.SCM_CHECKOUT_RETRY_COUNT ?: '1').toInteger())
+    int attempt = 0
+    while (true) {
+        try {
+            return checkout(params)
+        } catch (hudson.plugins.git.GitException e) {
+            attempt++
+            if (attempt >= maxRetries) { throw e }
+            echo "WARNING: SCM checkout failed (attempt ${attempt}/${maxRetries}), retrying in 15s: ${e.message}"
+            sleep(time: 15, unit: 'SECONDS')
+        }
+    }
 }

--- a/src/com/intel/checkoutScmInternal.groovy
+++ b/src/com/intel/checkoutScmInternal.groovy
@@ -17,11 +17,12 @@ Map checkoutScmInternal(Map config = [:]) {
    * @return Map of any variables the SCM plugin would set in a
    * Freestyle job.
    *
-    * config['scm'] SCM name, defaults to 'GitSCM'.
-    * config['url'] Url for SCM repository.  If not specified,
-    *  defaults will be used from the scm global variable.
-    * config['checkoutRetries'] Retry count override. Defaults to $SCM_CHECKOUT_RETRY_COUNT env var, then 1.
-    * config['cleanAfterCheckout'] True for clean after checkout.
+   * config['scm'] SCM name, defaults to 'GitSCM'.
+   * config['url'] Url for SCM repository.  If not specified,
+   *  defaults will be used from the scm global variable.
+   * config['checkoutRetries'] Retry count override. If not specified,
+   *  defaults to $SCM_CHECKOUT_RETRY_COUNT env var, then 1.
+   * config['cleanAfterCheckout'] True for clean after checkout.
    * config['checkoutDir'] Optional directory to checkout into.
    * config['branch'] Optional branch to checkout, defaults to master.
    * config['withSubmodules'] Optional checkout submodules if true.
@@ -93,9 +94,10 @@ Map checkoutScmInternal(Map config = [:]) {
            trackingSubmodules: false])
     }
 
-    int maxRetries = (config['checkoutRetries'] != null
-                      ? config['checkoutRetries']
-                      : (env.SCM_CHECKOUT_RETRY_COUNT ?: '1').toInteger())
+    int configuredRetries = (config['checkoutRetries'] != null
+                             ? config['checkoutRetries'].toString().toInteger()
+                             : (env.SCM_CHECKOUT_RETRY_COUNT ?: '1').toInteger())
+    int maxRetries = Math.max(1, configuredRetries)
     int attempt = 0
     while (true) {
         try {


### PR DESCRIPTION
Wrap the checkout() call in checkoutScmInternal with a retry loop to automatically recover from transient GitHub connectivity failures (fetch-pack: invalid index-pack output / git-remote-https signal 15).

Retry count is controlled by, in priority order:
  1. config['checkoutRetries'] passed by the caller
  2. SCM_CHECKOUT_RETRY_COUNT Jenkins environment variable
  3. Default of 1 (no retries, preserving existing behaviour)

Set SCM_CHECKOUT_RETRY_COUNT=3 in Jenkins global env to enable retries across all jobs without a further code change.