### PR TITLE
SRE-3982 test: Fix skipping passed Test stages in restart

### DIFF
--- a/vars/scriptedTestRpmStage.groovy
+++ b/vars/scriptedTestRpmStage.groovy
@@ -1,4 +1,4 @@
-/* groovylint-disable NestedBlockDepth */
+/* groovylint-disable DuplicateStringLiteral, NestedBlockDepth */
 // vars/scriptedTestRpmStage.groovy
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
@@ -38,6 +38,13 @@ Map call(Map kwargs = [:]) {
 
     if (!name) {
         error("scriptedTestRpmStage() requires a stage 'name' argument")
+    }
+
+    // Ensure the stage status file is included in the artifacts to be archived
+    if (archiveArtifactsArgs.containsKey('artifacts')) {
+        archiveArtifactsArgs['artifacts'] += ',' + stageStatusFilename(name)
+    } else {
+        archiveArtifactsArgs['artifacts'] = stageStatusFilename(name)
     }
 
     return {
@@ -96,10 +103,8 @@ Map call(Map kwargs = [:]) {
                                label: "Running alwaysScript: ${alwaysScript}",
                                returnStatus: true)
                         }
-                        if (archiveArtifactsArgs) {
-                            println("[${name}] Running archiveArtifacts()")
-                            archiveArtifacts(archiveArtifactsArgs)
-                        }
+                        println("[${name}] Running archiveArtifacts()")
+                        archiveArtifacts(archiveArtifactsArgs)
                         jobStatusUpdate(jobStatus, name)
                     /* groovylint-disable-next-line CatchException */
                     } catch (Exception finallyError) {

--- a/vars/scriptedTestRpmStage.groovy
+++ b/vars/scriptedTestRpmStage.groovy
@@ -48,6 +48,12 @@ Map call(Map kwargs = [:]) {
                 return
             }
 
+            if (stageAlreadyPassed()) {
+                println("[${name}] Stage skipped due to passing in the previous build")
+                Utils.markStageSkippedForConditional("${name}")
+                return
+            }
+
             // Add defaults for any missing testRpm() arguments
             if (!testRpmArgs.containsKey('inst_repos')) {
                 /* groovylint-disable-next-line DuplicateStringLiteral */

--- a/vars/scriptedUnitTestStage.groovy
+++ b/vars/scriptedUnitTestStage.groovy
@@ -1,4 +1,4 @@
-/* groovylint-disable NestedBlockDepth */
+/* groovylint-disable DuplicateStringLiteral, NestedBlockDepth */
 // vars/scriptedUnitTestStage.groovy
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
@@ -39,6 +39,13 @@ Map call(Map kwargs = [:]) {
 
     if (!name) {
         error("scriptedUnitTestStage() requires a stage 'name' argument")
+    }
+
+    // Ensure the stage status file is included in the artifacts to be archived
+    if (archiveArtifactsArgs.containsKey('artifacts')) {
+        archiveArtifactsArgs['artifacts'] += ',' + stageStatusFilename(name)
+    } else {
+        archiveArtifactsArgs['artifacts'] = stageStatusFilename(name)
     }
 
     return {
@@ -95,10 +102,8 @@ Map call(Map kwargs = [:]) {
                             println("[${name}] Running unitTestPost()")
                             unitTestPost(unitTestPostArgs)
                         }
-                        if (archiveArtifactsArgs) {
-                            println("[${name}] Running archiveArtifacts()")
-                            archiveArtifacts(archiveArtifactsArgs)
-                        }
+                        println("[${name}] Running archiveArtifacts()")
+                        archiveArtifacts(archiveArtifactsArgs)
                         jobStatusUpdate(jobStatus, name)
                     /* groovylint-disable-next-line CatchException */
                     } catch (Exception finallyError) {

--- a/vars/scriptedUnitTestStage.groovy
+++ b/vars/scriptedUnitTestStage.groovy
@@ -49,6 +49,12 @@ Map call(Map kwargs = [:]) {
                 return
             }
 
+            if (stageAlreadyPassed()) {
+                println("[${name}] Stage skipped due to passing in the previous build")
+                Utils.markStageSkippedForConditional("${name}")
+                return
+            }
+
             // Add defaults for any missing unitTest() arguments
             if (!unitTestArgs.containsKey('inst_repos')) {
                 /* groovylint-disable-next-line DuplicateStringLiteral */

--- a/vars/stepResult.groovy
+++ b/vars/stepResult.groovy
@@ -178,9 +178,7 @@ Void call(Map config= [:]) {
     }
     param['status'] = result
 
-    String statusFilename = stageStatusFilename()
-    println("stepResult: Writing ${statusFilename} with ${config['result']}")
-    writeFile(file: statusFilename, text: config['result'])
+    writeFile(file: stageStatusFilename(), text: config['result'])
 
     scmNotify param
     return

--- a/vars/stepResult.groovy
+++ b/vars/stepResult.groovy
@@ -178,7 +178,9 @@ Void call(Map config= [:]) {
     }
     param['status'] = result
 
-    writeFile(file: stageStatusFilename(), text: config['result'])
+    String statusFilename = stageStatusFilename()
+    println("stepResult: Writing ${statusFilename} with ${config['result']}")
+    writeFile(file: statusFilename, text: config['result'])
 
     scmNotify param
     return


### PR DESCRIPTION
When using 'Restart from Stage' the Fault injection testing and Test RPMs on * stages run in the new build even if they have passed in a previous build.  Re-enable the ability to skip these stages if they passed in the previous build.